### PR TITLE
Use acute MI incidence rate for both S-A and P-A

### DIFF
--- a/src/vivarium_nih_us_cvd/components/disease.py
+++ b/src/vivarium_nih_us_cvd/components/disease.py
@@ -20,7 +20,7 @@ def IschemicStroke():
     susceptible.allow_self_transitions()
     data_funcs = {
         "incidence_rate": lambda _, builder: builder.data.load(
-            data_keys.ISCHEMIC_STROKE.INCIDENCE_RATE
+            data_keys.ISCHEMIC_STROKE.INCIDENCE_RATE_ACUTE
         )
     }
     susceptible.add_transition(
@@ -31,7 +31,7 @@ def IschemicStroke():
     chronic_stroke.allow_self_transitions()
     data_funcs = {
         "transition_rate": lambda builder, *_: builder.data.load(
-            data_keys.ISCHEMIC_STROKE.INCIDENCE_RATE
+            data_keys.ISCHEMIC_STROKE.INCIDENCE_RATE_ACUTE
         )
     }
     chronic_stroke.add_transition(
@@ -48,7 +48,6 @@ def MyocardialInfarction():
     data_funcs = {"dwell_time": lambda *args: pd.Timedelta(days=28)}
     acute_myocardial_infarction = DiseaseState(
         models.ACUTE_MYOCARDIAL_INFARCTION_STATE_NAME,
-        # SDB - how do I know if the cause type is 'cause' or 'sequela'?
         cause_type="cause",
         get_data_functions=data_funcs,
     )
@@ -71,7 +70,7 @@ def MyocardialInfarction():
     post_myocardial_infarction.allow_self_transitions()
     data_funcs = {
         "transition_rate": lambda builder, *_: builder.data.load(
-            data_keys.MYOCARDIAL_INFARCTION.INCIDENCE_RATE_POST
+            data_keys.MYOCARDIAL_INFARCTION.INCIDENCE_RATE_ACUTE
         )
     }
     post_myocardial_infarction.add_transition(

--- a/src/vivarium_nih_us_cvd/constants/data_keys.py
+++ b/src/vivarium_nih_us_cvd/constants/data_keys.py
@@ -39,7 +39,7 @@ class __IschemicStroke(NamedTuple):
     PREVALENCE_CHRONIC: TargetString = TargetString(
         "sequela.chronic_ischemic_stroke.prevalence"
     )
-    INCIDENCE_RATE: TargetString = TargetString("cause.ischemic_stroke.incidence_rate")
+    INCIDENCE_RATE_ACUTE: TargetString = TargetString("cause.ischemic_stroke.incidence_rate")
     DISABILITY_WEIGHT_ACUTE: TargetString = TargetString(
         "sequela.acute_ischemic_stroke.disability_weight"
     )
@@ -77,10 +77,7 @@ class __MyocardialInfarction(NamedTuple):
         "cause.post_myocardial_infarction.prevalence"
     )
     INCIDENCE_RATE_ACUTE: TargetString = TargetString(
-        "cause.acute_myocardial_infarction.incidence_rate"
-    )
-    INCIDENCE_RATE_POST: TargetString = TargetString(
-        "cause.post_myocardial_infarction.incidence_rate"
+        "cause.myocardial_infarction.incidence_rate"
     )
     DISABILITY_WEIGHT_ACUTE: TargetString = TargetString(
         "cause.acute_myocardial_infarction.disability_weight"

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -57,7 +57,7 @@ def get_data(lookup_key: Union[str, data_keys.SourceTarget], location: str) -> p
         data_keys.POPULATION.ACMR: load_standard_data,
         data_keys.ISCHEMIC_STROKE.PREVALENCE_ACUTE: load_prevalence_ischemic_stroke,
         data_keys.ISCHEMIC_STROKE.PREVALENCE_CHRONIC: load_prevalence_ischemic_stroke,
-        data_keys.ISCHEMIC_STROKE.INCIDENCE_RATE: load_standard_data,
+        data_keys.ISCHEMIC_STROKE.INCIDENCE_RATE_ACUTE: load_standard_data,
         data_keys.ISCHEMIC_STROKE.DISABILITY_WEIGHT_ACUTE: load_disability_weight_ischemic_stroke,
         data_keys.ISCHEMIC_STROKE.DISABILITY_WEIGHT_CHRONIC: load_disability_weight_ischemic_stroke,
         data_keys.ISCHEMIC_STROKE.EMR_ACUTE: load_emr_ischemic_stroke,
@@ -67,7 +67,6 @@ def get_data(lookup_key: Union[str, data_keys.SourceTarget], location: str) -> p
         data_keys.MYOCARDIAL_INFARCTION.PREVALENCE_ACUTE: load_prevalence_ihd,
         data_keys.MYOCARDIAL_INFARCTION.PREVALENCE_POST: load_prevalence_ihd,
         data_keys.MYOCARDIAL_INFARCTION.INCIDENCE_RATE_ACUTE: load_incidence_ihd,
-        data_keys.MYOCARDIAL_INFARCTION.INCIDENCE_RATE_POST: load_incidence_ihd,
         data_keys.MYOCARDIAL_INFARCTION.DISABILITY_WEIGHT_ACUTE: load_disability_weight_ihd,
         data_keys.MYOCARDIAL_INFARCTION.DISABILITY_WEIGHT_POST: load_disability_weight_ihd,
         data_keys.MYOCARDIAL_INFARCTION.EMR_ACUTE: load_emr_ihd,
@@ -283,7 +282,6 @@ def load_incidence_ihd(key: str, location: str) -> pd.DataFrame:
     ihd_seq = _get_ihd_sequela()
     map = {
         data_keys.MYOCARDIAL_INFARCTION.INCIDENCE_RATE_ACUTE: (ihd_seq["acute_mi"], 24694),
-        data_keys.MYOCARDIAL_INFARCTION.INCIDENCE_RATE_POST: (ihd_seq["post_mi"], 24694),
     }
     sequela, meid = map[key]
     incidence = _load_em_from_meid(location, meid, "Incidence rate")


### PR DESCRIPTION
## Title: Fix post-MI incidence rate

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3321](https://jira.ihme.washington.edu/browse/MIC-3321)
- *Research reference*: [ischemic heart disease](https://vivarium-research.readthedocs.io/en/latest/gbd2019_models/causes/ihd/index.html#cause-ihd)

We are to use the same equation for S-A and P-A transitions. Currently,
they are different due to using the incorrect sequela when calculating the
denominator for post-MI. This PR removes the differentiation between
a post-MI and acute-MI and just uses one incidence rate for both.

### Verification and Testing
Confirmed a short test sim finished.

