### PR TITLE
Feature/sbachmei/mic 3314 model 2 ldlc observers

### DIFF
--- a/src/vivarium_nih_us_cvd/components/__init__.py
+++ b/src/vivarium_nih_us_cvd/components/__init__.py
@@ -1,2 +1,2 @@
 from .disease import IschemicStroke, MyocardialInfarction
-from .observers import ResultsStratifier
+from .observers import LdlcObserver, ResultsStratifier

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -25,8 +25,8 @@ class ResultsStratifier(ResultsStratifier_):
         self.register_stratifications(builder)
 
 
-class LdlcObserver():
-    """ Observes (continuous) LDL-Cholesterol exposure-time per group. """
+class LdlcObserver:
+    """Observes (continuous) LDL-Cholesterol exposure-time per group."""
 
     configuration_defaults = {
         "observers": {

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -70,7 +70,7 @@ class LdlcObserver():
         for label, group_mask in groups:
             key = f"ldl_c_exposure_time_{label}"
             group = pop[group_mask]
-            new_exposures[key] = group.ldlc.sum() * group_mask.sum() * event.step_size.days
+            new_exposures[key] = group.ldlc.sum() * group_mask.sum() * event.step_size.days / 365.25
 
         self.exposure.update(new_exposures)
 

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -70,7 +70,12 @@ class LdlcObserver():
         for label, group_mask in groups:
             key = f"ldl_c_exposure_time_{label}"
             group = pop[group_mask]
-            new_exposures[key] = group.ldlc.sum() * group_mask.sum() * event.step_size.days / 365.25
+            # SDB - do we multiply by group_mask.sum() (# of people) or not?
+            # new_exposures[key] = group.ldlc.sum() * group_mask.sum() * event.step_size.days / 365.25
+            new_exposures[key] = group.ldlc.sum() * event.step_size.days / 365.25
+            # (25+25+50 mmol/L)  * 1 year =  100 mmol/L-year
+            # Later, we'd have a 3 person-year column for this group
+            # so then 100 mmol/L-year / 3 person-year = 100 mmol/L/person
 
         self.exposure.update(new_exposures)
 

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -67,13 +67,13 @@ class LdlcObserver():
         pop = self.population_view.get(event.index, query='alive == "alive"')
         ldlc_exposure = self.ldlc(pop.index)
 
-        new_exposures = {}
+        new_observations = {}
         groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
         for label, group_mask in groups:
             key = f"total_ldl_c_exposure_time_{label}"
-            new_exposures[key] = ldlc_exposure[group_mask].sum() * step_size_in_years
+            new_observations[key] = ldlc_exposure[group_mask].sum() * step_size_in_years
 
-        self.exposure.update(new_exposures)
+        self.counter.update(new_observations)
 
     def metrics(self, index: "pd.Index", metrics: Dict[str, float]) -> Dict[str, float]:
         metrics.update(self.counter)

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -42,12 +42,12 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2040
+            year: 2023
             month: 12
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 50_000
+        population_size: 10_000
         age_start: 7
         age_end: 125
         exit_age: 125

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -43,12 +43,12 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2023
+            year: 2040
             month: 12
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 10_000
+        population_size: 50_000
         age_start: 7
         age_end: 125
         exit_age: 125

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -21,6 +21,7 @@ components:
             - IschemicStroke()
             - MyocardialInfarction()
             - ResultsStratifier()
+            - LdlcObserver()
         
 
 configuration:


### PR DESCRIPTION
## Title: model 2, risk ldl-c observer

### Description
- *Category*: observers
- *JIRA issue*: [MIC-3314](https://jira.ihme.washington.edu/browse/MIC-3314)

This is the observer for validation purposes; it observes the continuous
ldl-c exposure * time. Then, the RT can divide those values by
state-person-time for validation purposes.

In the long run, I suspect we'll need to observe a high/normal ldl-c
categorical value but there seems to be uncertainty on the thresholds,
units, etc. 

### Verification and Testing
Confirmed that the exposure-time divided by total person-time per age-sex-year
group is very similar to the artifacts mean_exposure values for those groups.

