### PR TITLE
Add min/max sbp exposure limits

### DIFF
--- a/src/vivarium_nih_us_cvd/components/risks.py
+++ b/src/vivarium_nih_us_cvd/components/risks.py
@@ -6,9 +6,10 @@ from vivarium_public_health.risks.base_risk import Risk as Risk_
 from vivarium_nih_us_cvd.constants.data_values import RISK_EXPOSURE_LIMITS
 
 
+# FIXME: would be more proper to modify the distribution function itself
 class Risk(Risk_):
     """Use the standard vivarium_public_health Risk class for risk
-    exposure except limit to lower and upper bounds.
+    exposure except apply limits to lower and upper bounds (when defined).
     """
 
     def _get_current_exposure(self, index: pd.Index) -> pd.Series:

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -43,4 +43,8 @@ RISK_EXPOSURE_LIMITS = {
         "minimum": 0,
         "maximum": 10,
     },
+    "high_systolic_blood_pressure": {
+        "minimum": 50,
+        "maximum": 300,
+    },
 }


### PR DESCRIPTION
## Title: Implement SBP exposure limits

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3353](https://jira.ihme.washington.edu/browse/MIC-3353)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/gbd2019_models/risk_exposures/sbp/index.html#risk-sbp

Limits sbp exposure to [50,300].

### Verification and Testing
Ran a 1-year test and made results
