### PR TITLE
implement exposure to ldlc medication

### DIFF
--- a/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
+++ b/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
@@ -246,11 +246,7 @@ class HealthcareUtilization:
     def determine_followups_sbp(self, pop_visitors: pd.DataFrame) -> pd.Index:
         """Apply SBP treatment ramp logic to determine who gets scheduled a followup"""
         visitors = pop_visitors.index
-        measured_sbp = self.treatment.get_measured_sbp(
-            index=visitors,
-            mean=data_values.MEASUREMENT_ERROR_MEAN_SBP,
-            sd=data_values.MEASUREMENT_ERROR_SD_SBP,
-        )
+        measured_sbp = self.treatment.get_measured_sbp(index=visitors)
         visitors_high_sbp = visitors.intersection(
             measured_sbp[measured_sbp >= data_values.SBP_THRESHOLD.LOW].index
         )
@@ -269,11 +265,7 @@ class HealthcareUtilization:
         """Apply LDL-C treatment ramp logic to determine who gets scheduled a followup"""
         visitors = pop_visitors.index
         ascvd = self.treatment.get_ascvd(pop_visitors=pop_visitors)
-        measured_ldlc = self.treatment.get_measured_ldlc(
-            index=visitors,
-            mean=data_values.MEASUREMENT_ERROR_MEAN_LDLC,
-            sd=data_values.MEASUREMENT_ERROR_SD_LDLC,
-        )
+        measured_ldlc = self.treatment.get_measured_ldlc(index=visitors)
         visitors_high_ascvd = visitors.intersection(
             ascvd[ascvd >= data_values.ASCVD_THRESHOLD.LOW].index
         )

--- a/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
+++ b/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
@@ -218,20 +218,18 @@ class HealthcareUtilization:
 
         # Schedule followups
         all_visitors = visit_emergency.union(visit_scheduled).union(visit_background)
-        needs_followup_sbp = self.determine_followups_sbp(
-            visitors=all_visitors, pop_visitors=pop.loc[all_visitors]
-        )
+        needs_followup_sbp = self.determine_followups_sbp(pop_visitors=pop.loc[all_visitors])
         needs_followup_ldlc = self.determine_followups_ldlc(
-            visitors=all_visitors, pop_visitors=pop.loc[all_visitors]
+            pop_visitors=pop.loc[all_visitors]
         )
         # Do not schedule a followup if one already exists
         has_followup_already_scheduled = pop[
             (pop[data_values.COLUMNS.SCHEDULED_VISIT_DATE] > event_time)
         ].index
 
-        to_schedule_followup = (
-            needs_followup_sbp.union(needs_followup_ldlc)
-        ).difference(has_followup_already_scheduled)
+        to_schedule_followup = (needs_followup_sbp.union(needs_followup_ldlc)).difference(
+            has_followup_already_scheduled
+        )
         pop.loc[
             to_schedule_followup, data_values.COLUMNS.SCHEDULED_VISIT_DATE
         ] = self.schedule_followup(index=to_schedule_followup, event_time=event_time)
@@ -245,10 +243,9 @@ class HealthcareUtilization:
             ]
         )
 
-    def determine_followups_sbp(
-        self, visitors: pd.Index, pop_visitors: pd.DataFrame
-    ) -> pd.Index:
+    def determine_followups_sbp(self, pop_visitors: pd.DataFrame) -> pd.Index:
         """Apply SBP treatment ramp logic to determine who gets scheduled a followup"""
+        visitors = pop_visitors.index
         measured_sbp = self.treatment.get_measured_sbp(
             index=visitors,
             mean=data_values.MEASUREMENT_ERROR_MEAN_SBP,
@@ -268,11 +265,10 @@ class HealthcareUtilization:
 
         return needs_followup
 
-    def determine_followups_ldlc(
-        self, visitors: pd.Index, pop_visitors: pd.DataFrame
-    ) -> pd.Index:
+    def determine_followups_ldlc(self, pop_visitors: pd.DataFrame) -> pd.Index:
         """Apply LDL-C treatment ramp logic to determine who gets scheduled a followup"""
-        ascvd = self.treatment.get_ascvd(visitors=visitors)
+        visitors = pop_visitors.index
+        ascvd = self.treatment.get_ascvd(pop_visitors=pop_visitors)
         measured_ldlc = self.treatment.get_measured_ldlc(
             index=visitors,
             mean=data_values.MEASUREMENT_ERROR_MEAN_LDLC,

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -590,13 +590,14 @@ class Treatment:
         """Introduce a measurement error to the sbp exposure values"""
         if not exposure_pipeline:
             exposure_pipeline = self.sbp
-        return exposure_pipeline(index) + get_random_value_from_normal_distribution(
+        
+        return (exposure_pipeline(index) + get_random_value_from_normal_distribution(
             index=index,
             mean=mean,
             sd=sd,
             randomness=self.randomness,
             additional_key="measured_sbp",
-        )
+        )).clip(lower=0)
 
     def get_ascvd(
         self, pop_visitors: pd.DataFrame, sbp_pipeline: Optional[Pipeline] = None
@@ -625,10 +626,11 @@ class Treatment:
         """Introduce a measurement error to the ldlc exposure values"""
         if not exposure_pipeline:
             exposure_pipeline = self.ldlc
-        return exposure_pipeline(index) + get_random_value_from_normal_distribution(
+        
+        return (exposure_pipeline(index) + get_random_value_from_normal_distribution(
             index=index,
             mean=mean,
             sd=sd,
             randomness=self.randomness,
             additional_key="measured_ldlc",
-        )
+        )).clip(lower=0)

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -490,8 +490,7 @@ class Treatment:
         )
         history_mi_or_is = pop_visitors[mask_history_mi | mask_history_is].index
         newly_prescribed = (
-            overcome_therapeutic_inertia
-            .difference(currently_medicated)
+            overcome_therapeutic_inertia.difference(currently_medicated)
             .difference(low_ascvd)
             .difference(low_ldlc)
         )
@@ -499,36 +498,29 @@ class Treatment:
         # [Treatment ramp ID D] Simulants who overcome therapeutic inertia, have
         # elevated LDLC, are not currently medicated, have elevated ASCVD, and
         # have a history of MI or IS
-        to_prescribe_d = (
-            newly_prescribed
-            .intersection(history_mi_or_is)
-        )
+        to_prescribe_d = newly_prescribed.intersection(history_mi_or_is)
         # [Treatment ramp ID E] Simulants who overcome therapeutic inertia, have
         # elevated LDLC, are not currently medicated, have elevated ASCVD, have
         # no history of MI or IS, and who have high LDLC or ASCVD
-        to_prescribe_e = (
-            newly_prescribed
-            .difference(to_prescribe_d)
-            .intersection(high_ascvd.union(high_ldlc))
+        to_prescribe_e = newly_prescribed.difference(to_prescribe_d).intersection(
+            high_ascvd.union(high_ldlc)
         )
         # [Treatment ramp ID F] Simulants who overcome therapeutic inertia, have
         # elevated LDLC, are not currently medicated, have elevated ASCVD, have
         # no history of MI or IS, but who do NOT have high LDLC or ASCVD
-        to_prescribe_f = (
-            newly_prescribed
-            .difference(to_prescribe_d)
-            .difference(to_prescribe_e)
+        to_prescribe_f = newly_prescribed.difference(to_prescribe_d).difference(
+            to_prescribe_e
         )
         # [Treatment ramp ID G] Simulants who overcome therapeutic inertia, have
         # elevated LDLC, and are currently medicated
-        to_prescribe_g = (
-            overcome_therapeutic_inertia
-            .intersection(currently_medicated)
-            .difference(low_ldlc)
-        )
+        to_prescribe_g = overcome_therapeutic_inertia.intersection(
+            currently_medicated
+        ).difference(low_ldlc)
 
         # Prescribe initial medications
-        df_newly_prescribed = pd.DataFrame(index=to_prescribe_e.union(to_prescribe_f).union(to_prescribe_d))
+        df_newly_prescribed = pd.DataFrame(
+            index=to_prescribe_e.union(to_prescribe_f).union(to_prescribe_d)
+        )
         # TODO: CONFIRM THESE LISTS REMAIN ORDERED HERE AND IN randomness.choice
         df_newly_prescribed.loc[
             to_prescribe_d,

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -382,8 +382,6 @@ class Treatment:
 
         measured_sbp = self.get_measured_sbp(
             index=pop_visitors.index,
-            mean=data_values.MEASUREMENT_ERROR_MEAN_SBP,
-            sd=data_values.MEASUREMENT_ERROR_SD_SBP,
             exposure_pipeline=exposure_pipeline,
         )
 
@@ -475,8 +473,6 @@ class Treatment:
         ascvd = self.get_ascvd(pop_visitors=pop_visitors, sbp_pipeline=sbp_pipeline)
         measured_ldlc = self.get_measured_ldlc(
             index=pop_visitors.index,
-            mean=data_values.MEASUREMENT_ERROR_MEAN_LDLC,
-            sd=data_values.MEASUREMENT_ERROR_SD_LDLC,
             exposure_pipeline=ldlc_pipeline,
         )
 
@@ -583,8 +579,6 @@ class Treatment:
     def get_measured_sbp(
         self,
         index: pd.Index,
-        mean: float,
-        sd: float,
         exposure_pipeline: Optional[Pipeline] = None,
     ) -> pd.Series:
         """Introduce a measurement error to the sbp exposure values"""
@@ -593,8 +587,8 @@ class Treatment:
         
         return (exposure_pipeline(index) + get_random_value_from_normal_distribution(
             index=index,
-            mean=mean,
-            sd=sd,
+            mean=data_values.MEASUREMENT_ERROR_MEAN_SBP,
+            sd=data_values.MEASUREMENT_ERROR_SD_SBP,
             randomness=self.randomness,
             additional_key="measured_sbp",
         )).clip(lower=0)
@@ -619,18 +613,16 @@ class Treatment:
     def get_measured_ldlc(
         self,
         index: pd.Index,
-        mean: float,
-        sd: float,
         exposure_pipeline: Optional[Pipeline] = None,
     ) -> pd.Series:
         """Introduce a measurement error to the ldlc exposure values"""
         if not exposure_pipeline:
             exposure_pipeline = self.ldlc
-        
+
         return (exposure_pipeline(index) + get_random_value_from_normal_distribution(
             index=index,
-            mean=mean,
-            sd=sd,
+            mean=data_values.MEASUREMENT_ERROR_MEAN_LDLC,
+            sd=data_values.MEASUREMENT_ERROR_SD_LDLC,
             randomness=self.randomness,
             additional_key="measured_ldlc",
         )).clip(lower=0)

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -518,10 +518,7 @@ class Treatment:
         ).difference(low_ldlc)
 
         # Prescribe initial medications
-        df_newly_prescribed = pd.DataFrame(
-            index=to_prescribe_e.union(to_prescribe_f).union(to_prescribe_d)
-        )
-        # TODO: CONFIRM THESE LISTS REMAIN ORDERED HERE AND IN randomness.choice
+        df_newly_prescribed = pd.DataFrame(index=newly_prescribed)
         df_newly_prescribed.loc[
             to_prescribe_d,
             data_values.FIRST_PRESCRIPTION_LEVEL_PROBABILITY["ldlc"]["ramp_id_d"].keys(),
@@ -535,9 +532,9 @@ class Treatment:
             data_values.FIRST_PRESCRIPTION_LEVEL_PROBABILITY["ldlc"]["ramp_id_f"].keys(),
         ] = data_values.FIRST_PRESCRIPTION_LEVEL_PROBABILITY["ldlc"]["ramp_id_f"].values()
         pop_visitors.loc[
-            df_newly_prescribed.index, data_values.COLUMNS.LDLC_MEDICATION
+            newly_prescribed, data_values.COLUMNS.LDLC_MEDICATION
         ] = self.randomness.choice(
-            df_newly_prescribed.index,
+            newly_prescribed,
             choices=df_newly_prescribed.columns,
             p=np.array(df_newly_prescribed),
             additional_key="high_ldlc_first_prescriptions",

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -492,7 +492,6 @@ class Treatment:
             != models.ISCHEMIC_STROKE_SUSCEPTIBLE_STATE_NAME
         )
         history_mi_or_is = pop_visitors[mask_history_mi | mask_history_is].index
-        no_history_mi_or_is = pop_visitors.index.difference(history_mi_or_is)
 
         # [Treatment ramp ID E] Simulants who overcome therapeutic inertia, have
         # elevated LDLC, are not currently medicated, have elevated ASCVD, have
@@ -501,7 +500,7 @@ class Treatment:
             overcome_therapeutic_inertia.intersection(elevated_ldlc)
             .intersection(not_currently_medicated)
             .intersection(elevated_ascvd)
-            .intersection(no_history_mi_or_is)
+            .difference(history_mi_or_is)
             .intersection(high_ascvd.union(high_ldlc))
         )
         # [Treatment ramp ID F] Simulants who overcome therapeutic inertia, have
@@ -511,7 +510,7 @@ class Treatment:
             overcome_therapeutic_inertia.intersection(elevated_ldlc)
             .intersection(not_currently_medicated)
             .intersection(elevated_ascvd)
-            .intersection(no_history_mi_or_is)
+            .difference(history_mi_or_is)
             .intersection(mid_ascvd.union(mid_ldlc))
         )
         # [Treatment ramp ID D] Simulants who overcome therapeutic inertia, have

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -584,14 +584,17 @@ class Treatment:
         """Introduce a measurement error to the sbp exposure values"""
         if not exposure_pipeline:
             exposure_pipeline = self.sbp
-        
-        return (exposure_pipeline(index) + get_random_value_from_normal_distribution(
-            index=index,
-            mean=data_values.MEASUREMENT_ERROR_MEAN_SBP,
-            sd=data_values.MEASUREMENT_ERROR_SD_SBP,
-            randomness=self.randomness,
-            additional_key="measured_sbp",
-        )).clip(lower=0)
+
+        return (
+            exposure_pipeline(index)
+            + get_random_value_from_normal_distribution(
+                index=index,
+                mean=data_values.MEASUREMENT_ERROR_MEAN_SBP,
+                sd=data_values.MEASUREMENT_ERROR_SD_SBP,
+                randomness=self.randomness,
+                additional_key="measured_sbp",
+            )
+        ).clip(lower=0)
 
     def get_ascvd(
         self, pop_visitors: pd.DataFrame, sbp_pipeline: Optional[Pipeline] = None
@@ -619,10 +622,13 @@ class Treatment:
         if not exposure_pipeline:
             exposure_pipeline = self.ldlc
 
-        return (exposure_pipeline(index) + get_random_value_from_normal_distribution(
-            index=index,
-            mean=data_values.MEASUREMENT_ERROR_MEAN_LDLC,
-            sd=data_values.MEASUREMENT_ERROR_SD_LDLC,
-            randomness=self.randomness,
-            additional_key="measured_ldlc",
-        )).clip(lower=0)
+        return (
+            exposure_pipeline(index)
+            + get_random_value_from_normal_distribution(
+                index=index,
+                mean=data_values.MEASUREMENT_ERROR_MEAN_LDLC,
+                sd=data_values.MEASUREMENT_ERROR_SD_LDLC,
+                randomness=self.randomness,
+                additional_key="measured_ldlc",
+            )
+        ).clip(lower=0)

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -372,7 +372,7 @@ class Treatment:
                 pop_visitors.index,
                 additional_key="sbp_therapeutic_inertia",
             )
-            > data_values.SBP_THERAPEUTIC_INERTIA_NO_START
+            > data_values.SBP_THERAPEUTIC_INERTIA
         ].index
         currently_medicated = pop_visitors[
             pop_visitors[data_values.COLUMNS.SBP_MEDICATION]
@@ -464,7 +464,7 @@ class Treatment:
                 pop_visitors.index,
                 additional_key="ldlc_therapeutic_inertia",
             )
-            > data_values.LDLC_THERAPEUTIC_INERTIA_NO_START
+            > data_values.LDLC_THERAPEUTIC_INERTIA
         ].index
         currently_medicated = pop_visitors[
             pop_visitors[data_values.COLUMNS.LDLC_MEDICATION]

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -101,13 +101,9 @@ VISIT_TYPE = __VisitType()
 # Medication Parameters #
 #########################
 
-SBP_THERAPEUTIC_INERTIA_NO_START = (
-    0.4176  # The chance that a patient will not have medication changed
-)
-
-LDLC_THERAPEUTIC_INERTIA_NO_START = (
-    0.194  # The chance that a patient will not have medication changed
-)
+# Therapeutic inertias (probability that a patient will not have their medication changed)
+SBP_THERAPEUTIC_INERTIA = 0.4176
+LDLC_THERAPEUTIC_INERTIA = 0.194
 
 
 class __SBPThreshold(NamedTuple):

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -101,8 +101,12 @@ VISIT_TYPE = __VisitType()
 # Medication Parameters #
 #########################
 
-THERAPEUTIC_INERTIA_NO_START = (
+SBP_THERAPEUTIC_INERTIA_NO_START = (
     0.4176  # The chance that a patient will not have medication changed
+)
+
+LDLC_THERAPEUTIC_INERTIA_NO_START = (
+    0.194  # The chance that a patient will not have medication changed
 )
 
 
@@ -146,7 +150,8 @@ ASCVD_SEX_MAPPING = {
 class __ASCVDThreshold(NamedTuple):
     """ASCVD thresholds"""
 
-    LOW: float = 7.5  # TODO: confirm whether this should be 7.5 or 0.075. NOTE: it ranges from ~[-17.35, 28.97]
+    LOW: float = 7.5
+    HIGH: float = 20
 
     @property
     def name(self):
@@ -160,6 +165,7 @@ class __LDLCThreshold(NamedTuple):
     """ldl-c exposure thresholds"""
 
     LOW: float = 1.81
+    HIGH: float = 4.91
 
     @property
     def name(self):
@@ -265,6 +271,32 @@ FIRST_PRESCRIPTION_LEVEL_PROBABILITY = {
             SBP_MEDICATION_LEVEL.TWO_DRUGS_HALF_DOSE.DESCRIPTION: 0.45,
         },
     },
+    "ldlc": {
+        # [Treatment ramp ID D] Simulants who overcome therapeutic inertia, have
+        # elevated LDLC, are not currently medicated, have elevated ASCVD, and
+        # have a history of MI or IS
+        "ramp_id_d": {
+            LDLC_MEDICATION_LEVEL.LOW.DESCRIPTION: 0.06,
+            LDLC_MEDICATION_LEVEL.MED.DESCRIPTION: 0.52,
+            LDLC_MEDICATION_LEVEL.HIGH.DESCRIPTION: 0.42,
+        },
+        # [Treatment ramp ID E] Simulants who overcome therapeutic inertia, have
+        # elevated LDLC, are not currently medicated, have elevated ASCVD, have
+        # no history of MI or IS, and who have high LDLC or ASCVD
+        "ramp_id_e": {
+            LDLC_MEDICATION_LEVEL.LOW.DESCRIPTION: 0.10,
+            LDLC_MEDICATION_LEVEL.MED.DESCRIPTION: 0.66,
+            LDLC_MEDICATION_LEVEL.HIGH.DESCRIPTION: 0.24,
+        },
+        # [Treatment ramp ID F] Simulants who overcome therapeutic inertia, have
+        # elevated LDLC, are not currently medicated, have elevated ASCVD, have
+        # no history of MI or IS, but who do NOT have high LDLC or ASCVD
+        "ramp_id_f": {
+            LDLC_MEDICATION_LEVEL.LOW.DESCRIPTION: 0.14,
+            LDLC_MEDICATION_LEVEL.MED.DESCRIPTION: 0.71,
+            LDLC_MEDICATION_LEVEL.HIGH.DESCRIPTION: 0.15,
+        },
+    },
 }
 
 
@@ -335,7 +367,7 @@ class __MedicationCoveragecoefficients(NamedTuple):
 
     @property
     def name(self):
-        return "medication coverage coefficients"
+        return "medication_coverage_coefficients"
 
 
 MEDICATION_COVERAGE_COEFFICIENTS = __MedicationCoveragecoefficients()

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -3,12 +3,12 @@ components:
         population:
             - BasePopulation()
             - Mortality()
-        metrics:
-            - MortalityObserver()
-            - DisabilityObserver()
-            - DiseaseObserver("ischemic_stroke")
-            - DiseaseObserver("myocardial_infarction")
-            - DiseaseObserver("angina")
+        # metrics:
+            # - MortalityObserver()
+            # - DisabilityObserver()
+            # - DiseaseObserver("ischemic_stroke")
+            # - DiseaseObserver("myocardial_infarction")
+            # - DiseaseObserver("angina")
         disease:
             - SI("angina")
         risks:
@@ -32,13 +32,13 @@ components:
             - MyocardialInfarction()
 
             - Risk("risk_factor.high_ldl_cholesterol")
-            - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
+            # - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
             
             - SBPRisk("risk_factor.high_systolic_blood_pressure")
-            - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
+            # - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
 
             - HealthcareUtilization() # Note that this uses Treatment() as a sub-component
-            - HealthcareVisitObserver()
+            # - HealthcareVisitObserver()
         
 
 configuration:
@@ -68,7 +68,7 @@ configuration:
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 50_000
+        population_size: 10_000
         age_start: 7
         age_end: 125
         exit_age: 125

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -3,12 +3,12 @@ components:
         population:
             - BasePopulation()
             - Mortality()
-        # metrics:
-            # - MortalityObserver()
-            # - DisabilityObserver()
-            # - DiseaseObserver("ischemic_stroke")
-            # - DiseaseObserver("myocardial_infarction")
-            # - DiseaseObserver("angina")
+        metrics:
+            - MortalityObserver()
+            - DisabilityObserver()
+            - DiseaseObserver("ischemic_stroke")
+            - DiseaseObserver("myocardial_infarction")
+            - DiseaseObserver("angina")
         disease:
             - SI("angina")
         risks:
@@ -32,13 +32,13 @@ components:
             - MyocardialInfarction()
 
             - Risk("risk_factor.high_ldl_cholesterol")
-            # - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
+            - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
             
             - SBPRisk("risk_factor.high_systolic_blood_pressure")
-            # - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
+            - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
 
             - HealthcareUtilization() # Note that this uses Treatment() as a sub-component
-            # - HealthcareVisitObserver()
+            - HealthcareVisitObserver()
         
 
 configuration:
@@ -68,7 +68,7 @@ configuration:
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 10_000
+        population_size: 50_000
         age_start: 7
         age_end: 125
         exit_age: 125


### PR DESCRIPTION
## Title: Implement exposure to LDL-C medication

### Description
- *Category*: Implementation
- *JIRA issue*: [MIC-3375](https://jira.ihme.washington.edu/browse/MIC-3375)
- *Research reference*: [system modeling](https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_us_cvd/concept_model.html#healthcare-system-modeling) (refer to the LDL-C Treatment Ramp)

This PR exposes simulants to the ldlc-treatment ramp and moves them up/down
the medication ramp as appropriate. Note that baseline ldlc medication coverage
already exists from a previous PR (ie, simulants were already initialized
with ldlc medication levels); but now they can go from a no treatment
state to a treatment state as well as move up the ramp as appropriate.

Also note that this does not yet implement the effect of the ldlc medication.

The majority of the changes lie in the self.apply_ldlc_treatment_ramp() method.
If helpful, refer to my proposed design here to see where the
logic is coming from: https://uwnetid-my.sharepoint.com/:u:/g/personal/sbachmei_uw_edu/EdHAaQc2PppPt2HumYvBeiABQpMhiIfgOQjnAqWGdXF77w?e=2m7RqH

### Verification and Testing
Ran interactively and ensured simulants are moving up the ldlc treatment ramp
