### PR TITLE
Feature/sbachmei/use manifest instead of package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include LICENSE
 include README.rst
 
 recursive-include src/vivarium_nih_us_cvd *.py *.yaml *.ipynb
+recursive-include src/vivarium_nih_us_cvd/data *.csv
 recursive-include tests *.py *txt *.yaml

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         packages=find_packages(where="src"),
         include_package_data=True,
-        package_data={"vivarium_nih_us_csv": ["data/drug_efficacy_sbp.csv"]},
         install_requires=install_requirements,
         extras_require={
             "test": test_requirements,


### PR DESCRIPTION
## Title: Rely on MANIFEST for including datasets rather than package_data

### Description
- *Category*: other
- *JIRA issue*: n/a
- *Research reference*: n/a

I previously implemented the inclusion of .csv datasets via package_data
in setup.py. I've since realized we're using MANIFEST so moved
the inclusion there.

### Verification and Testing


