### PR TITLE
Feature/sbachmei/mic 3377 ldlc medication observer

### DIFF
--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -46,7 +46,9 @@ class ResultsStratifier(ResultsStratifier_):
         self.setup_stratification(
             builder,
             name=data_values.COLUMNS.LDLC_MEDICATION_ADHERENCE,
-            sources=[Source(data_values.COLUMNS.LDLC_MEDICATION_ADHERENCE, SourceType.COLUMN)],
+            sources=[
+                Source(data_values.COLUMNS.LDLC_MEDICATION_ADHERENCE, SourceType.COLUMN)
+            ],
             categories={level for level in data_values.MEDICATION_ADHERENCE_TYPE},
         )
 
@@ -234,7 +236,9 @@ class MedicationObserver:
     def _get_configuration_defaults(self) -> Dict[str, Dict]:
         return {
             "observers": {
-                self.medication_type: MedicationObserver.configuration_defaults["observers"]["medication"]
+                self.medication_type: MedicationObserver.configuration_defaults["observers"][
+                    "medication"
+                ]
             }
         }
 

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -43,6 +43,13 @@ class ResultsStratifier(ResultsStratifier_):
             categories={level for level in data_values.MEDICATION_ADHERENCE_TYPE},
         )
 
+        self.setup_stratification(
+            builder,
+            name=data_values.COLUMNS.LDLC_MEDICATION_ADHERENCE,
+            sources=[Source(data_values.COLUMNS.LDLC_MEDICATION_ADHERENCE, SourceType.COLUMN)],
+            categories={level for level in data_values.MEDICATION_ADHERENCE_TYPE},
+        )
+
 
 class ContinuousRiskObserver:
     """Observes (continuous) risk exposure-time per group."""
@@ -205,17 +212,17 @@ class MedicationObserver:
 
     configuration_defaults = {
         "observers": {
-            "sbp_medication": {
+            "medication": {
                 "exclude": [],
                 "include": [],
-            }
-        }
+            },
+        },
     }
 
     def __init__(self, risk):
-        self.configuration_defaults = self._get_configuration_defaults()
         self.medication_type = self._get_medication_type(risk)
         self.medication_levels = self._get_medication_levels(risk)
+        self.configuration_defaults = self._get_configuration_defaults()
 
     def __repr__(self):
         return f"MedicationObserver({self.medication_type})"
@@ -225,11 +232,16 @@ class MedicationObserver:
     ##########################
 
     def _get_configuration_defaults(self) -> Dict[str, Dict]:
-        return MedicationObserver.configuration_defaults
+        return {
+            "observers": {
+                self.medication_type: MedicationObserver.configuration_defaults["observers"]["medication"]
+            }
+        }
 
     def _get_medication_type(self, risk: str) -> str:
         mapping = {
             "risk_factor.high_systolic_blood_pressure": data_values.COLUMNS.SBP_MEDICATION,
+            "risk_factor.high_ldl_cholesterol": data_values.COLUMNS.LDLC_MEDICATION,
         }
 
         return mapping[risk]
@@ -237,6 +249,7 @@ class MedicationObserver:
     def _get_medication_levels(self, risk: str) -> List[str]:
         mapping = {
             "risk_factor.high_systolic_blood_pressure": data_values.SBP_MEDICATION_LEVEL,
+            "risk_factor.high_ldl_cholesterol": data_values.LDLC_MEDICATION_LEVEL,
         }
 
         return [level.DESCRIPTION for level in mapping[risk]]

--- a/src/vivarium_nih_us_cvd/constants/results.py
+++ b/src/vivarium_nih_us_cvd/constants/results.py
@@ -45,7 +45,8 @@ RISK_EXPOSURE_TIME_TEMPLATE = (
     "total_exposure_time_risk_{RISK}_year_{YEAR}_sex_{SEX}_age_{AGE_GROUP}"
 )
 VISIT_COUNT_TEMPLATE = "healthcare_visits_{VISIT_TYPE}_year_{YEAR}_sex_{SEX}_age_{AGE_GROUP}"
-MEDICATION_PERSON_TIME_TEMPLATE = "{MEDICATION_TYPE}_person_time_{MEDICATION}_year_{YEAR}_sex_{SEX}_age_{AGE_GROUP}_medication_adherence_{MEDICATION_ADHERENCE_LEVEL}"
+SBP_MEDICATION_PERSON_TIME_TEMPLATE = "sbp_medication_person_time_{SBP_MEDICATION}_year_{YEAR}_sex_{SEX}_age_{AGE_GROUP}_medication_adherence_{MEDICATION_ADHERENCE_LEVEL}"
+LDLC_MEDICATION_PERSON_TIME_TEMPLATE = "ldlc_medication_person_time_{LDLC_MEDICATION}_year_{YEAR}_sex_{SEX}_age_{AGE_GROUP}_medication_adherence_{MEDICATION_ADHERENCE_LEVEL}"
 
 
 COLUMN_TEMPLATES = {
@@ -57,7 +58,8 @@ COLUMN_TEMPLATES = {
     "transition_count": TRANSITION_COUNT_COLUMN_TEMPLATE,
     "risk_exposure_time": RISK_EXPOSURE_TIME_TEMPLATE,
     "healthcare_visits": VISIT_COUNT_TEMPLATE,
-    "medication_person_time": MEDICATION_PERSON_TIME_TEMPLATE,
+    "sbp_medication_person_time": SBP_MEDICATION_PERSON_TIME_TEMPLATE,
+    "ldlc_medication_person_time": LDLC_MEDICATION_PERSON_TIME_TEMPLATE,
 }
 
 NON_COUNT_TEMPLATES = []
@@ -97,8 +99,8 @@ RISKS = (
     "high_systolic_blood_pressure",
 )
 MEDICATION_ADHERENCE_LEVELS = tuple(x for x in data_values.MEDICATION_ADHERENCE_TYPE)
-MEDICATION_TYPES = (data_values.COLUMNS.SBP_MEDICATION,)
-MEDICATIONS = tuple(x.DESCRIPTION for x in data_values.SBP_MEDICATION_LEVEL)
+SBP_MEDICATIONS = tuple(x.DESCRIPTION for x in data_values.SBP_MEDICATION_LEVEL)
+LDLC_MEDICATIONS = tuple(x.DESCRIPTION for x in data_values.LDLC_MEDICATION_LEVEL)
 
 TEMPLATE_FIELD_MAP = {
     "POP_STATE": POP_STATES,
@@ -112,8 +114,8 @@ TEMPLATE_FIELD_MAP = {
     "RISK": RISKS,
     "VISIT_TYPE": data_values.VISIT_TYPE,
     "MEDICATION_ADHERENCE_LEVEL": MEDICATION_ADHERENCE_LEVELS,
-    "MEDICATION_TYPE": MEDICATION_TYPES,
-    "MEDICATION": MEDICATIONS,
+    "SBP_MEDICATION": SBP_MEDICATIONS,
+    "LDLC_MEDICATION": LDLC_MEDICATIONS,
 }
 
 

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -3,7 +3,7 @@ components:
         population:
             - BasePopulation()
             - Mortality()
-        # metrics:
+        metrics:
             - MortalityObserver()
             - DisabilityObserver()
             - DiseaseObserver("ischemic_stroke")
@@ -41,6 +41,7 @@ components:
             - HealthcareVisitObserver()
         
             - MedicationObserver("risk_factor.high_systolic_blood_pressure")
+            - MedicationObserver("risk_factor.high_ldl_cholesterol")
 
 configuration:
     input_data:
@@ -81,4 +82,7 @@ configuration:
         sbp_medication:
             include:
                 - 'sbp_medication_adherence'
+        ldlc_medication:
+            include:
+                - 'ldlc_medication_adherence'
         

--- a/src/vivarium_nih_us_cvd/results_processing/process_results.py
+++ b/src/vivarium_nih_us_cvd/results_processing/process_results.py
@@ -27,31 +27,35 @@ RENAME_COLUMNS = {
 # TODO [MIC-3219]: - update template
 def make_measure_data(data):
     measure_data = MeasureData(
-        population=get_population_data(data),
-        ylls=get_by_cause_measure_data(data, "ylls"),
-        ylds=get_by_cause_measure_data(data, "ylds"),
-        deaths=get_by_cause_measure_data(data, "deaths"),
-        state_person_time=get_state_person_time_measure_data(data, "state_person_time"),
-        transition_count=get_transition_count_measure_data(data, "transition_count"),
-        risk_exposure_time=get_risk_exposure_time_data(data, "risk_exposure_time"),
-        healthcare_visits=get_healthcare_visit_data(data, "healthcare_visits"),
-        medication_person_time=get_medication_person_time_data(
-            data, "medication_person_time"
+        # population=get_population_data(data),
+        # ylls=get_by_cause_measure_data(data, "ylls"),
+        # ylds=get_by_cause_measure_data(data, "ylds"),
+        # deaths=get_by_cause_measure_data(data, "deaths"),
+        # state_person_time=get_state_person_time_measure_data(data, "state_person_time"),
+        # transition_count=get_transition_count_measure_data(data, "transition_count"),
+        # risk_exposure_time=get_risk_exposure_time_data(data, "risk_exposure_time"),
+        # healthcare_visits=get_healthcare_visit_data(data, "healthcare_visits"),
+        sbp_medication_person_time=get_medication_person_time_data(
+            data, "sbp_medication_person_time"
+        ),
+        ldlc_medication_person_time=get_medication_person_time_data(
+            data, "ldlc_medication_person_time"
         ),
     )
     return measure_data
 
 
 class MeasureData(NamedTuple):
-    population: pd.DataFrame
-    ylls: pd.DataFrame
-    ylds: pd.DataFrame
-    deaths: pd.DataFrame
-    state_person_time: pd.DataFrame
-    transition_count: pd.DataFrame
-    risk_exposure_time: pd.DataFrame
-    healthcare_visits: pd.DataFrame
-    medication_person_time: pd.DataFrame
+    # population: pd.DataFrame
+    # ylls: pd.DataFrame
+    # ylds: pd.DataFrame
+    # deaths: pd.DataFrame
+    # state_person_time: pd.DataFrame
+    # transition_count: pd.DataFrame
+    # risk_exposure_time: pd.DataFrame
+    # healthcare_visits: pd.DataFrame
+    sbp_medication_person_time: pd.DataFrame
+    ldlc_medication_person_time: pd.DataFrame
 
     def dump(self, output_dir: Path):
         for key, df in self._asdict().items():


### PR DESCRIPTION
## Title: LDLC medication observer

### Description
- *Category*: observers
- *JIRA issue*: [MIC-3377](https://jira.ihme.washington.edu/browse/MIC-3377)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_us_cvd/concept_model.html#model-outputs

This adds the observer for ldlc-medication. Unfortunately, the way I've implemented
it, it saves out different datasets for sbp and ldlc medications. I'd love feedback
on if/how I can get that all into one dataset!

Basically I'd like one dataset (medication_person_time.csv) stratified by
medication type, age, sex, year, adherence level.

### Verification and Testing
Ran a small sim and confirmed the count data generated

