### PR TITLE
Feature/sbachmei/mic 3555 exposure to outreach

### DIFF
--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -242,7 +242,6 @@ class Treatment:
         ).get(pop_data.index)
 
         # Generate initial medication adherence columns and initialize coverage
-        breakpoint()
         pop[data_values.COLUMNS.SBP_MEDICATION_ADHERENCE] = self.sbp_medication_adherence(
             pop.index
         )
@@ -365,7 +364,6 @@ class Treatment:
         )
 
         # # Move medicated but non-adherent simulants to lowest level
-        breakpoint()
         sbp_non_adherent = pop[
             pop[data_values.COLUMNS.SBP_MEDICATION_ADHERENCE]
             != data_values.MEDICATION_ADHERENCE_TYPE.ADHERENT

--- a/src/vivarium_nih_us_cvd/constants/data_keys.py
+++ b/src/vivarium_nih_us_cvd/constants/data_keys.py
@@ -223,6 +223,25 @@ class __HighSBP(NamedTuple):
 SBP = __HighSBP()
 
 
+class __LDLCholesterolMedicationAdherence(NamedTuple):
+    DISTRIBUTION: TargetString = TargetString("risk_factor.ldlc_medication_adherence.distribution")
+
+    @property
+    def name(self):
+        return "ldlc_medication_adherence"
+
+    @property
+    def log_name(self):
+        return self.name.replace("_", " ")
+
+
+LDLC_MEDICATION_ADHERENCE = __LDLCholesterolMedicationAdherence()
+
+
+##################
+# Artifact Items #
+##################
+
 MAKE_ARTIFACT_KEY_GROUPS = [
     POPULATION,
     ISCHEMIC_STROKE,
@@ -230,4 +249,5 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     ANGINA,
     LDL_C,
     SBP,
+    LDLC_MEDICATION_ADHERENCE,
 ]

--- a/src/vivarium_nih_us_cvd/constants/data_keys.py
+++ b/src/vivarium_nih_us_cvd/constants/data_keys.py
@@ -259,6 +259,23 @@ class __SBPMedicationAdherence(NamedTuple):
 SBP_MEDICATION_ADHERENCE = __SBPMedicationAdherence()
 
 
+class __Outreach(NamedTuple):
+    DISTRIBUTION: TargetString = TargetString(
+        "risk_factor.outreach.distribution"
+    )
+
+    @property
+    def name(self):
+        return "outreach"
+
+    @property
+    def log_name(self):
+        return self.name.replace("_", " ")
+
+
+OUTREACH = __Outreach()
+
+
 ##################
 # Artifact Items #
 ##################
@@ -272,4 +289,5 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     SBP,
     LDLC_MEDICATION_ADHERENCE,
     SBP_MEDICATION_ADHERENCE,
+    OUTREACH,
 ]

--- a/src/vivarium_nih_us_cvd/constants/data_keys.py
+++ b/src/vivarium_nih_us_cvd/constants/data_keys.py
@@ -224,7 +224,10 @@ SBP = __HighSBP()
 
 
 class __LDLCholesterolMedicationAdherence(NamedTuple):
-    DISTRIBUTION: TargetString = TargetString("risk_factor.ldlc_medication_adherence.distribution")
+    DISTRIBUTION: TargetString = TargetString(
+        "risk_factor.ldlc_medication_adherence.distribution"
+    )
+    EXPOSURE: TargetString = TargetString("risk_factor.ldlc_medication_adherence.exposure")
 
     @property
     def name(self):
@@ -236,6 +239,24 @@ class __LDLCholesterolMedicationAdherence(NamedTuple):
 
 
 LDLC_MEDICATION_ADHERENCE = __LDLCholesterolMedicationAdherence()
+
+
+class __SBPMedicationAdherence(NamedTuple):
+    DISTRIBUTION: TargetString = TargetString(
+        "risk_factor.sbp_medication_adherence.distribution"
+    )
+    EXPOSURE: TargetString = TargetString("risk_factor.sbp_medication_adherence.exposure")
+
+    @property
+    def name(self):
+        return "sbp_medication_adherence"
+
+    @property
+    def log_name(self):
+        return self.name.replace("_", " ")
+
+
+SBP_MEDICATION_ADHERENCE = __SBPMedicationAdherence()
 
 
 ##################
@@ -250,4 +271,5 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     LDL_C,
     SBP,
     LDLC_MEDICATION_ADHERENCE,
+    SBP_MEDICATION_ADHERENCE,
 ]

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -43,6 +43,7 @@ class __Pipelines(NamedTuple):
     LDLC_EXPOSURE: str = "high_ldl_cholesterol.exposure"
     SBP_MEDICATION_ADHERENCE_EXPOSURE: str = "sbp_medication_adherence.exposure"
     LDLC_MEDICATION_ADHERENCE_EXPOSURE: str = "ldlc_medication_adherence.exposure"
+    OUTREACH_EXPOSURE: str = "outreach.exposure"
 
     @property
     def name(self):

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -373,21 +373,6 @@ class __MedicationAdherenceType(NamedTuple):
 MEDICATION_ADHERENCE_TYPE = __MedicationAdherenceType()
 
 
-# Define medication adherence level probabilitiies
-MEDICATION_ADHERENCE_TYPE_PROBABILITIY = {
-    "sbp": {
-        MEDICATION_ADHERENCE_TYPE.ADHERENT: 0.7392,
-        MEDICATION_ADHERENCE_TYPE.PRIMARY_NON_ADHERENT: 0.16,
-        MEDICATION_ADHERENCE_TYPE.SECONDARY_NON_ADHERENT: 0.1008,
-    },
-    "ldlc": {
-        MEDICATION_ADHERENCE_TYPE.ADHERENT: 0.6525,
-        MEDICATION_ADHERENCE_TYPE.PRIMARY_NON_ADHERENT: 0.25,
-        MEDICATION_ADHERENCE_TYPE.SECONDARY_NON_ADHERENT: 0.0975,
-    },
-}
-
-
 BASELINE_MEDICATION_COVERAGE_SEX_MAPPING = {
     # used in medication treatment effect calculation
     "Female": 2,

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -41,6 +41,8 @@ class __Pipelines(NamedTuple):
     SBP_EXPOSURE: str = "high_systolic_blood_pressure.exposure"
     LDLC_GBD_EXPOSURE: str = "high_ldl_cholesterol.gbd_exposure"
     LDLC_EXPOSURE: str = "high_ldl_cholesterol.exposure"
+    SBP_MEDICATION_ADHERENCE_EXPOSURE: str = "sbp_medication_adherence.exposure"
+    LDLC_MEDICATION_ADHERENCE_EXPOSURE: str = "ldlc_medication_adherence.exposure"
 
     @property
     def name(self):
@@ -361,9 +363,9 @@ FIRST_PRESCRIPTION_LEVEL_PROBABILITY = {
 class __MedicationAdherenceType(NamedTuple):
     """medication adherence types"""
 
-    ADHERENT: str = "adherent"
-    PRIMARY_NON_ADHERENT: str = "primary_non_adherent"
-    SECONDARY_NON_ADHERENT: str = "secondary_non_adherent"
+    PRIMARY_NON_ADHERENT: str = "cat1"
+    SECONDARY_NON_ADHERENT: str = "cat2"
+    ADHERENT: str = "cat3"
 
     @property
     def name(self):
@@ -371,6 +373,21 @@ class __MedicationAdherenceType(NamedTuple):
 
 
 MEDICATION_ADHERENCE_TYPE = __MedicationAdherenceType()
+
+
+# Define medication adherence level probabilitiies
+MEDICATION_ADHERENCE_TYPE_PROBABILITIY = {
+    "sbp_medication_adherence": {
+        MEDICATION_ADHERENCE_TYPE.PRIMARY_NON_ADHERENT: 0.16,
+        MEDICATION_ADHERENCE_TYPE.SECONDARY_NON_ADHERENT: 0.1008,
+        MEDICATION_ADHERENCE_TYPE.ADHERENT: 0.7392,
+    },
+    "ldlc_medication_adherence": {
+        MEDICATION_ADHERENCE_TYPE.PRIMARY_NON_ADHERENT: 0.25,
+        MEDICATION_ADHERENCE_TYPE.SECONDARY_NON_ADHERENT: 0.0975,
+        MEDICATION_ADHERENCE_TYPE.ADHERENT: 0.6525,
+    },
+}
 
 
 BASELINE_MEDICATION_COVERAGE_SEX_MAPPING = {

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -119,6 +119,8 @@ def get_data(lookup_key: Union[str, data_keys.SourceTarget], location: str) -> p
         # Risk (sbp medication adherence)
         data_keys.SBP_MEDICATION_ADHERENCE.DISTRIBUTION: load_medication_adherence_distribution,
         data_keys.SBP_MEDICATION_ADHERENCE.EXPOSURE: load_medication_adherence_exposure,
+        # Risk (outreach)
+        data_keys.OUTREACH.DISTRIBUTION: load_outreach_distribution,
     }
     source_key = _get_source_key(lookup_key)
     data = mapping[lookup_key](source_key, location)
@@ -525,3 +527,7 @@ def load_medication_adherence_exposure(key: str, location: str) -> pd.DataFrame:
         data_values.MEDICATION_ADHERENCE_TYPE.ADHERENT
     ]
     return df.set_index("parameter", append=True)
+
+
+def load_outreach_distribution(key: str, location: str) -> str:
+    return "dichotomous"

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -511,6 +511,7 @@ def load_medication_adherence_exposure(key: str, location: str) -> pd.DataFrame:
     # Merge on the categorical thresholds
     draws = [f"draw_{i}" for i in range(1000)]
     df = pd.concat([df, pd.DataFrame(columns=draws, dtype=float)])
+    # cat1 is most severe -> catN is least severe (tmrel)
     df.loc[
         df["parameter"] == "cat1", draws
     ] = data_values.MEDICATION_ADHERENCE_TYPE_PROBABILITIY[key.name][

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -104,7 +104,7 @@ def get_data(lookup_key: Union[str, data_keys.SourceTarget], location: str) -> p
         data_keys.LDL_C.TMRED: load_metadata,
         data_keys.LDL_C.RELATIVE_RISK_SCALAR: load_metadata,
         data_keys.LDL_C.MEDICATION_EFFECT: load_ldlc_medication_effect,
-        # Risk (stystolic blood pressure)
+        # Risk (systolic blood pressure)
         data_keys.SBP.DISTRIBUTION: load_metadata,
         data_keys.SBP.EXPOSURE_MEAN: load_standard_data,
         data_keys.SBP.EXPOSURE_SD: load_standard_data,
@@ -113,6 +113,8 @@ def get_data(lookup_key: Union[str, data_keys.SourceTarget], location: str) -> p
         data_keys.SBP.PAF: load_standard_data,
         data_keys.SBP.TMRED: load_metadata,
         data_keys.SBP.RELATIVE_RISK_SCALAR: load_metadata,
+        # Risk (ldlc medication adherence)
+        data_keys.LDLC_MEDICATION_ADHERENCE.DISTRIBUTION: load_metadata,
     }
     source_key = _get_source_key(lookup_key)
     data = mapping[lookup_key](source_key, location)
@@ -160,6 +162,7 @@ def load_standard_data(key: str, location: str) -> pd.DataFrame:
 
 
 def load_metadata(key: str, location: str):
+    breakpoint()
     key = EntityKey(key)
     entity = get_entity(key)
     entity_metadata = entity[key.measure]

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -90,4 +90,4 @@ configuration:
             include:
                 - 'ldlc_medication_adherence'
     outreach:
-        exposure: 0.0  # cat2
+        exposure: 0.0

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -12,6 +12,9 @@ components:
         disease:
             - SI("angina")
         risks:
+            - Risk("risk_factor.sbp_medication_adherence")
+            - Risk("risk_factor.ldlc_medication_adherence")
+
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_ischemic_stroke.incidence_rate")
@@ -86,3 +89,13 @@ configuration:
             include:
                 - 'ldlc_medication_adherence'
         
+    baseline_medication_adherence_sbp:
+        category_thresholds: # NOTE: the order here matters
+            - 0.16 # primary non-adherent
+            - 0.1008 # secondary non-adherent
+            - 0.7392 # adherent
+    baseline_medication_adherence_ldlc:
+        category_thresholds: # NOTE: the order here matters
+            - 0.25 # primary non-adherent
+            - 0.0975 # secondary non-adherent
+            - 0.6525 # adherent

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -3,12 +3,12 @@ components:
         population:
             - BasePopulation()
             - Mortality()
-        metrics:
-            - MortalityObserver()
-            - DisabilityObserver()
-            - DiseaseObserver("ischemic_stroke")
-            - DiseaseObserver("myocardial_infarction")
-            - DiseaseObserver("angina")
+        # metrics:
+        #     - MortalityObserver()
+        #     - DisabilityObserver()
+        #     - DiseaseObserver("ischemic_stroke")
+        #     - DiseaseObserver("myocardial_infarction")
+        #     - DiseaseObserver("angina")
         disease:
             - SI("angina")
         risks:
@@ -35,16 +35,16 @@ components:
             - MyocardialInfarction()
 
             - AdjustedRisk("risk_factor.high_ldl_cholesterol")
-            - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
+            # - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
             
             - AdjustedRisk("risk_factor.high_systolic_blood_pressure")
-            - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
+            # - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
 
             - HealthcareUtilization() # Note that this uses Treatment() as a sub-component
-            - HealthcareVisitObserver()
+            # - HealthcareVisitObserver()
         
-            - MedicationObserver("risk_factor.high_systolic_blood_pressure")
-            - MedicationObserver("risk_factor.high_ldl_cholesterol")
+            # - MedicationObserver("risk_factor.high_systolic_blood_pressure")
+            # - MedicationObserver("risk_factor.high_ldl_cholesterol")
 
 configuration:
     input_data:
@@ -73,7 +73,7 @@ configuration:
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 50_000
+        population_size: 10_000
         age_start: 7
         age_end: 125
         exit_age: 125
@@ -88,14 +88,3 @@ configuration:
         ldlc_medication:
             include:
                 - 'ldlc_medication_adherence'
-        
-    baseline_medication_adherence_sbp:
-        category_thresholds: # NOTE: the order here matters
-            - 0.16 # primary non-adherent
-            - 0.1008 # secondary non-adherent
-            - 0.7392 # adherent
-    baseline_medication_adherence_ldlc:
-        category_thresholds: # NOTE: the order here matters
-            - 0.25 # primary non-adherent
-            - 0.0975 # secondary non-adherent
-            - 0.6525 # adherent

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -14,6 +14,7 @@ components:
         risks:
             - Risk("risk_factor.sbp_medication_adherence")
             - Risk("risk_factor.ldlc_medication_adherence")
+            - Risk("risk_factor.outreach")
 
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
@@ -88,3 +89,5 @@ configuration:
         ldlc_medication:
             include:
                 - 'ldlc_medication_adherence'
+    outreach:
+        exposure: 0.0  # cat2

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -3,12 +3,12 @@ components:
         population:
             - BasePopulation()
             - Mortality()
-        # metrics:
-        #     - MortalityObserver()
-        #     - DisabilityObserver()
-        #     - DiseaseObserver("ischemic_stroke")
-        #     - DiseaseObserver("myocardial_infarction")
-        #     - DiseaseObserver("angina")
+        metrics:
+            - MortalityObserver()
+            - DisabilityObserver()
+            - DiseaseObserver("ischemic_stroke")
+            - DiseaseObserver("myocardial_infarction")
+            - DiseaseObserver("angina")
         disease:
             - SI("angina")
         risks:
@@ -35,16 +35,16 @@ components:
             - MyocardialInfarction()
 
             - AdjustedRisk("risk_factor.high_ldl_cholesterol")
-            # - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
+            - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
             
             - AdjustedRisk("risk_factor.high_systolic_blood_pressure")
-            # - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
+            - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
 
             - HealthcareUtilization() # Note that this uses Treatment() as a sub-component
-            # - HealthcareVisitObserver()
+            - HealthcareVisitObserver()
         
-            # - MedicationObserver("risk_factor.high_systolic_blood_pressure")
-            # - MedicationObserver("risk_factor.high_ldl_cholesterol")
+            - MedicationObserver("risk_factor.high_systolic_blood_pressure")
+            - MedicationObserver("risk_factor.high_ldl_cholesterol")
 
 configuration:
     input_data:
@@ -73,7 +73,7 @@ configuration:
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 10_000
+        population_size: 50_000
         age_start: 7
         age_end: 125
         exit_age: 125

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -90,4 +90,8 @@ configuration:
             include:
                 - 'ldlc_medication_adherence'
     outreach:
-        exposure: 0.0
+        # NOTE: For outreach, we are changing our standard heuristic of categories
+        # being mapped highest to lowest where cat1 is highest risk. Here, an 
+        # outreach.exposure = 0.0 is the highest risk (no outreach means less
+        # likely to take medication) but will map to cat2 (not cat1)
+        exposure: 0


### PR DESCRIPTION
## Title: Exposure to outreach

### Description
- *Category*: Implementation
- *JIRA issue*: [MIC-3555](https://jira.ihme.washington.edu/browse/MIC-3555)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/intervention_models/crm_mgmt/vivarium_outreach.html

This simply adds outreach as a risk factor. The model does not yet
actually use the pipeline.

NOTE: The mapping of exposure to categories for Outreach is
backwards than the standard heuristic. That is, simulants exposed
to the outreach program have a less severe risk effect (b/c they will 
be more likely to take their medication) but they will be mapped as
cat1. Those not exposed to outreach (most severe) will be cat2.

(it was either swap this mapping or change the risk to something like
"risk_effect.no_exposure" which seemed weird)

### Verification and Testing
I confirmed in an interactive sim that we are appropriately mapping
people exposed to outreach to cat1 and those not exposed to
cat2.

