### PR TITLE
bugfix model spec; simplify LinearScaleUp config default methods

### DIFF
--- a/src/vivarium_nih_us_cvd/components/interventions.py
+++ b/src/vivarium_nih_us_cvd/components/interventions.py
@@ -36,7 +36,7 @@ class LinearScaleUp(LinearScaleUp_):
 
     def _get_scale_up_dates(self, builder: Builder) -> Tuple[datetime, datetime]:
         scale_up_config = builder.configuration[self.configuration_key]["date"]
-        endpoints = []
+        endpoints = {}
         for endpoint_type in ["start", "end"]:
             if (
                 (scale_up_config[endpoint_type]["year"] == f"{endpoint_type}_year")
@@ -46,19 +46,19 @@ class LinearScaleUp(LinearScaleUp_):
                 endpoint = get_time_stamp(builder.configuration.time[endpoint_type])
             else:
                 endpoint = get_time_stamp(scale_up_config[endpoint_type])
-            endpoints.append(endpoint)
+            endpoints[endpoint_type] = endpoint
 
-        return endpoints[0], endpoints[1]
+        return endpoints["start"], endpoints["end"]
 
     # NOTE: Re-defining to test for future vph fix
     def _get_scale_up_values(self, builder: Builder) -> Tuple[LookupTable, LookupTable]:
         scale_up_config = builder.configuration[self.configuration_key]["value"]
-        endpoints = []
+        endpoints = {}
         for endpoint_type in ["start", "end"]:
             if scale_up_config[endpoint_type] == "data":
                 endpoint = self._get_endpoint_value_from_data(builder, endpoint_type)
             else:
                 endpoint = builder.lookup.build_table(scale_up_config[endpoint_type])
-            endpoints.append(endpoint)
+            endpoints[endpoint_type] = endpoint
 
-        return endpoints[0], endpoints[1]
+        return endpoints["start"], endpoints["end"]

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -48,11 +48,8 @@ components:
             - CategoricalColumnObserver("ldlc_medication")
 
             - OutreachEffect()
-            - OutreachInterventionScaleUp("risk_factor.outreach")
-            - CategoricalColumnObserver("outreach")
-
-            - OutreachEffect()
             - LinearScaleUp("risk_factor.outreach")
+            - CategoricalColumnObserver("outreach")
 
 configuration:
     input_data:


### PR DESCRIPTION
## Title: Simplify LinearScaleUp config defautl getters

### Description
- *Category*: misc
- *JIRA issue*: n/a
- *Research reference*: n/a

As long as we're going into the LinearScaleUp class for a [bugfix](https://jira.ihme.washington.edu/browse/MIC-3579),
this simplifies the date and value start/end configuration default methods

### Verification and Testing
Ran several time steps and confirmed same results

