### PR TITLE
indent scaleup values into intervention list

### DIFF
--- a/src/vivarium_nih_us_cvd/components/interventions.py
+++ b/src/vivarium_nih_us_cvd/components/interventions.py
@@ -35,7 +35,7 @@ class LinearScaleUp(LinearScaleUp_):
         return {self.configuration_key: LinearScaleUp.configuration_defaults["treatment"]}
 
     def _get_scale_up_dates(self, builder: Builder) -> Tuple[datetime, datetime]:
-        scale_up_config = builder.configuration[self.configuration_key]["date"]
+        scale_up_config = builder.configuration.intervention[self.configuration_key]["date"]
         endpoints = {}
         for endpoint_type in ["start", "end"]:
             if (
@@ -52,7 +52,7 @@ class LinearScaleUp(LinearScaleUp_):
 
     # NOTE: Re-defining to test for future vph fix
     def _get_scale_up_values(self, builder: Builder) -> Tuple[LookupTable, LookupTable]:
-        scale_up_config = builder.configuration[self.configuration_key]["value"]
+        scale_up_config = builder.configuration.intervention[self.configuration_key]["value"]
         endpoints = {}
         for endpoint_type in ["start", "end"]:
             if scale_up_config[endpoint_type] == "data":

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -101,17 +101,17 @@ configuration:
         # likely to take medication) but will map to cat2 (not cat1)
         exposure: 0
     intervention:
-        scenario: "outreach_50"
-    outreach_scale_up:
-        date:
-            start:
-                year: 2023
-                month: 1
-                day: 1
-            end:
-                year: 2024
-                month: 1
-                day: 1
-        value:
-            start: 0
-            end: 0.5
+        scenario: "outreach_test_run"
+        outreach_scale_up:
+            date:
+                start:
+                    year: 2023
+                    month: 1
+                    day: 1
+                end:
+                    year: 2024
+                    month: 1
+                    day: 1
+            value:
+                start: 0
+                end: 0.5


### PR DESCRIPTION
## Title: indent scaleup values in model spec to match branches

### Description
- *Category*: bugfix
- *JIRA issue*: na
- *Research reference*: na

The model spec scaleup value was used for all non-baseline scenarios 
because the mappings did not exactly match between the two yamls.

### Verification and Testing
ran a small psimulate and confirmed scaling up correctly

