### PR TITLE
add bmi max; update vivarium_inputs pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     # use "pip install -e .[dev]" to install required components + extra components
     data_requires = [
         "vivarium_cluster_tools==1.3.7",
-        "vivarium_inputs[data]==4.0.8",
+        "vivarium_inputs[data]==4.0.9",
     ]
 
     test_requirements = ["pytest"]

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -459,6 +459,7 @@ RISK_EXPOSURE_LIMITS = {
     },
     "high_body_mass_index_in_adults": {
         "minimum": 5,
+        "maximum": 80,
     },
 }
 


### PR DESCRIPTION
## Title: Add max BMI threshold

### Description
- *Category*: other
- *JIRA issue*: [MIC-3623](https://jira.ihme.washington.edu/browse/MIC-3623)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/risk_exposures/bmi/index.html#risk-bmi

### Changes and notes
Forces all BMI to be <= 80.
(also pins the newest vivarium_inputs)

### Verification and Testing
