### PR TITLE
Categorical sbp risk exposure

### DIFF
--- a/src/vivarium_nih_us_cvd/components/__init__.py
+++ b/src/vivarium_nih_us_cvd/components/__init__.py
@@ -3,5 +3,5 @@ from .effects import InterventionAdherenceEffect
 from .healthcare_utilization import HealthcareUtilization
 from .interventions import LinearScaleUp
 from .paf_observer import PAFObserver
-from .risks import AdjustedRisk, TruncatedRisk
+from .risks import AdjustedRisk, CategoricalSBPRisk, TruncatedRisk
 from .treatment import Treatment

--- a/src/vivarium_nih_us_cvd/components/paf_observer.py
+++ b/src/vivarium_nih_us_cvd/components/paf_observer.py
@@ -56,6 +56,8 @@ class PAFObserver:
     def get_configuration_defaults(self) -> Dict[str, Dict]:
         return {
             "stratification": {
-                f"{self.risk.name}_paf": PAFObserver.configuration_defaults["stratification"]["paf"]
+                f"{self.risk.name}_paf": PAFObserver.configuration_defaults["stratification"][
+                    "paf"
+                ]
             }
         }

--- a/src/vivarium_nih_us_cvd/components/paf_observer.py
+++ b/src/vivarium_nih_us_cvd/components/paf_observer.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 import pandas as pd
 from vivarium.framework.engine import Builder
-from vivarium_public_health.utilities import TargetString
+from vivarium_public_health.utilities import EntityString, TargetString
 
 
 class PAFObserver:
@@ -17,8 +17,8 @@ class PAFObserver:
     }
 
     def __init__(self, risk: str, target: str):
-        self.risk = risk
-        self.target = target
+        self.risk = EntityString(risk)
+        self.target = TargetString(target)
         self.configuration_defaults = self.get_configuration_defaults()
 
     def __repr__(self):
@@ -34,8 +34,7 @@ class PAFObserver:
             f"risk_effect.{self.risk}.{self.target}"
         )
 
-        risk_name = TargetString(self.risk + ".some_measure").name
-        config = builder.configuration.stratification[f"{risk_name}_paf"]
+        config = builder.configuration.stratification[f"{self.risk.name}_paf"]
 
         builder.results.register_observation(
             name=f"calculated_paf_{self.risk}_on_{self.target}",
@@ -57,6 +56,6 @@ class PAFObserver:
     def get_configuration_defaults(self) -> Dict[str, Dict]:
         return {
             "stratification": {
-                self.risk: PAFObserver.configuration_defaults["stratification"]["paf"]
+                f"{self.risk.name}_paf": PAFObserver.configuration_defaults["stratification"]["paf"]
             }
         }

--- a/src/vivarium_nih_us_cvd/components/risks.py
+++ b/src/vivarium_nih_us_cvd/components/risks.py
@@ -163,4 +163,3 @@ class CategoricalSBPRisk:
         )  # left interval is closed, right interval is open
 
         return categorical_exposure
-    

--- a/src/vivarium_nih_us_cvd/components/risks.py
+++ b/src/vivarium_nih_us_cvd/components/risks.py
@@ -8,7 +8,12 @@ from vivarium_public_health.risks.data_transformations import (
 )
 from vivarium_public_health.utilities import EntityString
 
-from vivarium_nih_us_cvd.constants.data_values import CATEGORICAL_SBP_INTERVALS, COLUMNS, RISK_EXPOSURE_LIMITS, PIPELINES
+from vivarium_nih_us_cvd.constants.data_values import (
+    CATEGORICAL_SBP_INTERVALS,
+    COLUMNS,
+    PIPELINES,
+    RISK_EXPOSURE_LIMITS,
+)
 
 
 class AdjustedRisk(Risk):
@@ -87,6 +92,7 @@ class AdjustedRisk(Risk):
 
 class TruncatedRisk(Risk):
     """Keep exposure values between defined limits"""
+
     def _get_current_exposure(self, index: pd.Index) -> pd.Series:
         # Keep exposure values between defined limits
         propensity = self.propensity(index)
@@ -141,15 +147,20 @@ class CategoricalSBPRisk:
     def _get_current_exposure(self, index: pd.Index) -> pd.Series:
         continuous_exposure = self.continuous_exposure(index)
 
-        bins = [RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["minimum"],
-                CATEGORICAL_SBP_INTERVALS.CAT3_LEFT_THRESHOLD,
-                CATEGORICAL_SBP_INTERVALS.CAT2_LEFT_THRESHOLD,
-                CATEGORICAL_SBP_INTERVALS.CAT1_LEFT_THRESHOLD,
-                RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["maximum"]]
+        bins = [
+            RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["minimum"],
+            CATEGORICAL_SBP_INTERVALS.CAT3_LEFT_THRESHOLD,
+            CATEGORICAL_SBP_INTERVALS.CAT2_LEFT_THRESHOLD,
+            CATEGORICAL_SBP_INTERVALS.CAT1_LEFT_THRESHOLD,
+            RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["maximum"],
+        ]
 
-        categorical_exposure = pd.cut(continuous_exposure,
-                                      bins = bins,
-                                      labels = ['cat4', 'cat3', 'cat2', 'cat1'],
-                                      right = False) # left interval is closed, right interval is open
+        categorical_exposure = pd.cut(
+            continuous_exposure,
+            bins=bins,
+            labels=["cat4", "cat3", "cat2", "cat1"],
+            right=False,
+        )  # left interval is closed, right interval is open
 
         return categorical_exposure
+    

--- a/src/vivarium_nih_us_cvd/components/risks.py
+++ b/src/vivarium_nih_us_cvd/components/risks.py
@@ -6,8 +6,9 @@ from vivarium_public_health.risks.base_risk import Risk
 from vivarium_public_health.risks.data_transformations import (
     get_exposure_post_processor,
 )
+from vivarium_public_health.utilities import EntityString
 
-from vivarium_nih_us_cvd.constants.data_values import COLUMNS, RISK_EXPOSURE_LIMITS
+from vivarium_nih_us_cvd.constants.data_values import CATEGORICAL_SBP_INTERVALS, COLUMNS, RISK_EXPOSURE_LIMITS, PIPELINES
 
 
 class AdjustedRisk(Risk):
@@ -85,6 +86,7 @@ class AdjustedRisk(Risk):
 
 
 class TruncatedRisk(Risk):
+    """Keep exposure values between defined limits"""
     def _get_current_exposure(self, index: pd.Index) -> pd.Series:
         # Keep exposure values between defined limits
         propensity = self.propensity(index)
@@ -96,3 +98,58 @@ class TruncatedRisk(Risk):
         exposures[exposures > max_exposure] = max_exposure
 
         return exposures
+
+
+class CategoricalSBPRisk:
+    """Bin continuous systolic blood pressure values into categories"""
+
+    def __init__(self):
+        self.risk = EntityString("risk_factor.categorical_high_systolic_blood_pressure")
+        self.exposure_pipeline_name = f"{self.risk.name}.exposure"
+
+    def __repr__(self) -> str:
+        return "CategoricalSBPRisk()"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self) -> str:
+        return f"risk.{self.risk}"
+
+    #################
+    # Setup methods #
+    #################
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.continuous_exposure = builder.value.get_value(PIPELINES.SBP_EXPOSURE)
+        self.exposure = self._get_exposure_pipeline(builder)
+
+    def _get_exposure_pipeline(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.exposure_pipeline_name,
+            source=self._get_current_exposure,
+            requires_values=[PIPELINES.SBP_EXPOSURE],
+        )
+
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################
+
+    def _get_current_exposure(self, index: pd.Index) -> pd.Series:
+        continuous_exposure = self.continuous_exposure(index)
+
+        bins = [RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["minimum"],
+                CATEGORICAL_SBP_INTERVALS.CAT3_LEFT_THRESHOLD,
+                CATEGORICAL_SBP_INTERVALS.CAT2_LEFT_THRESHOLD,
+                CATEGORICAL_SBP_INTERVALS.CAT1_LEFT_THRESHOLD,
+                RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["maximum"]]
+
+        categorical_exposure = pd.cut(continuous_exposure,
+                                      bins = bins,
+                                      labels = ['cat4', 'cat3', 'cat2', 'cat1'],
+                                      right = False) # left interval is closed, right interval is open
+
+        return categorical_exposure

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -469,7 +469,7 @@ RISK_EXPOSURE_LIMITS = {
 
 
 class __CategoricalSBPIntervals(NamedTuple):
-    """ldl-c exposure thresholds"""
+    """categorical sbp exposure thresholds"""
 
     CAT3_LEFT_THRESHOLD: int = 120
     CAT2_LEFT_THRESHOLD: int = 130

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -467,6 +467,22 @@ RISK_EXPOSURE_LIMITS = {
     },
 }
 
+
+class __CategoricalSBPIntervals(NamedTuple):
+    """ldl-c exposure thresholds"""
+
+    CAT3_LEFT_THRESHOLD: int = 120
+    CAT2_LEFT_THRESHOLD: int = 130
+    CAT1_LEFT_THRESHOLD: int = 140
+
+    @property
+    def name(self):
+        return "categorical_sbp_intervals"
+
+
+CATEGORICAL_SBP_INTERVALS = __CategoricalSBPIntervals()
+
+
 MAX_BMI_STANDARD_DEVIATION = 15
 
 


### PR DESCRIPTION
## Categorical sbp risk exposure

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3839](https://jira.ihme.washington.edu/browse/MIC-3839)
- *Research reference*: [SBP Groups](https://vivarium-research.readthedocs.io/en/latest/models/risk_effects/sbp/index.html#risk-outcome-pair-10-heart-failure)

### Changes and notes
Some changes to PAF observer based on discussion with Rajan.

### Verification and Testing
Checked minimum and maximum values of simulants in all categories of categorical sbp exposure in interactive context to made sure they were within the correct intervals (all simulants in cat3 were between 120 and 130 for example). 