### PR TITLE
Define PAF model spec

### DIFF
--- a/src/vivarium_nih_us_cvd/components/__init__.py
+++ b/src/vivarium_nih_us_cvd/components/__init__.py
@@ -1,5 +1,5 @@
 from .disease import IschemicHeartDiseaseAndHeartFailure, IschemicStroke
-from .effects import InterventionAdherenceEffect
+from .effects import PAFCalculationRiskEffect, InterventionAdherenceEffect
 from .healthcare_utilization import HealthcareUtilization
 from .interventions import LinearScaleUp
 from .paf_observer import PAFObserver

--- a/src/vivarium_nih_us_cvd/components/__init__.py
+++ b/src/vivarium_nih_us_cvd/components/__init__.py
@@ -1,5 +1,5 @@
 from .disease import IschemicHeartDiseaseAndHeartFailure, IschemicStroke
-from .effects import PAFCalculationRiskEffect, InterventionAdherenceEffect
+from .effects import InterventionAdherenceEffect, PAFCalculationRiskEffect
 from .healthcare_utilization import HealthcareUtilization
 from .interventions import LinearScaleUp
 from .paf_observer import PAFObserver

--- a/src/vivarium_nih_us_cvd/components/effects.py
+++ b/src/vivarium_nih_us_cvd/components/effects.py
@@ -1,13 +1,12 @@
-import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium.framework.time import get_time_stamp
-from vivarium.framework.lookup import LookupTable
-
 from typing import Callable
 
-from vivarium_nih_us_cvd.constants import data_values, scenarios
-
+import pandas as pd
+from vivarium.framework.engine import Builder
+from vivarium.framework.lookup import LookupTable
+from vivarium.framework.time import get_time_stamp
 from vivarium_public_health.risks.effect import RiskEffect
+
+from vivarium_nih_us_cvd.constants import data_values, scenarios
 
 
 class InterventionAdherenceEffect:

--- a/src/vivarium_nih_us_cvd/components/effects.py
+++ b/src/vivarium_nih_us_cvd/components/effects.py
@@ -1,8 +1,13 @@
 import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.time import get_time_stamp
+from vivarium.framework.lookup import LookupTable
+
+from typing import Callable
 
 from vivarium_nih_us_cvd.constants import data_values, scenarios
+
+from vivarium_public_health.risks.effect import RiskEffect
 
 
 class InterventionAdherenceEffect:
@@ -98,3 +103,30 @@ class InterventionAdherenceEffect:
             target.loc[on_polypill, cat] = probability
 
         return target
+
+
+class PAFCalculationRiskEffect(RiskEffect):
+    """Risk effect component for calculating PAFs"""
+
+    def __repr__(self):
+        return f"PAFCalculationRiskEffect(risk={self.risk}, target={self.target})"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self) -> str:
+        return f"paf_calculation_risk_effect.{self.risk}.{self.target}"
+
+    #################
+    # Setup methods #
+    #################
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.exposure_distribution_type = self._get_distribution_type(builder)
+        self.exposure = self._get_risk_exposure(builder)
+        self.relative_risk = self._get_relative_risk_source(builder)
+
+        self.target_modifier = self._get_target_modifier(builder)

--- a/src/vivarium_nih_us_cvd/components/paf_observer.py
+++ b/src/vivarium_nih_us_cvd/components/paf_observer.py
@@ -31,7 +31,7 @@ class PAFObserver:
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
         self.risk_effect = builder.components.get_component(
-            f"risk_effect.{self.risk}.{self.target}"
+            f"paf_calculation_risk_effect.{self.risk}.{self.target}"
         )
 
         config = builder.configuration.stratification[f"{self.risk.name}_paf"]

--- a/src/vivarium_nih_us_cvd/components/risks.py
+++ b/src/vivarium_nih_us_cvd/components/risks.py
@@ -1,6 +1,7 @@
-import pandas as pd
-import numpy as np
 from typing import Dict
+
+import numpy as np
+import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.population.manager import PopulationView
 from vivarium.framework.values import Pipeline

--- a/src/vivarium_nih_us_cvd/components/risks.py
+++ b/src/vivarium_nih_us_cvd/components/risks.py
@@ -1,4 +1,6 @@
 import pandas as pd
+import numpy as np
+from typing import Dict
 from vivarium.framework.engine import Builder
 from vivarium.framework.population.manager import PopulationView
 from vivarium.framework.values import Pipeline
@@ -109,12 +111,24 @@ class TruncatedRisk(Risk):
 class CategoricalSBPRisk:
     """Bin continuous systolic blood pressure values into categories"""
 
+    configuration_defaults = {
+        "risk": {
+            "exposure": "data",
+            "rebinned_exposed": [],
+            "category_thresholds": [],
+        }
+    }
+
     def __init__(self):
         self.risk = EntityString("risk_factor.categorical_high_systolic_blood_pressure")
+        self.configuration_defaults = self._get_configuration_defaults()
         self.exposure_pipeline_name = f"{self.risk.name}.exposure"
 
     def __repr__(self) -> str:
         return "CategoricalSBPRisk()"
+
+    def _get_configuration_defaults(self) -> Dict[str, Dict]:
+        return {self.risk.name: Risk.configuration_defaults["risk"]}
 
     ##############
     # Properties #
@@ -148,11 +162,12 @@ class CategoricalSBPRisk:
         continuous_exposure = self.continuous_exposure(index)
 
         bins = [
-            RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["minimum"],
+            0,
             CATEGORICAL_SBP_INTERVALS.CAT3_LEFT_THRESHOLD,
             CATEGORICAL_SBP_INTERVALS.CAT2_LEFT_THRESHOLD,
             CATEGORICAL_SBP_INTERVALS.CAT1_LEFT_THRESHOLD,
-            RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["maximum"],
+            #RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["maximum"],
+            np.inf,
         ]
 
         categorical_exposure = pd.cut(

--- a/src/vivarium_nih_us_cvd/components/risks.py
+++ b/src/vivarium_nih_us_cvd/components/risks.py
@@ -166,7 +166,6 @@ class CategoricalSBPRisk:
             CATEGORICAL_SBP_INTERVALS.CAT3_LEFT_THRESHOLD,
             CATEGORICAL_SBP_INTERVALS.CAT2_LEFT_THRESHOLD,
             CATEGORICAL_SBP_INTERVALS.CAT1_LEFT_THRESHOLD,
-            #RISK_EXPOSURE_LIMITS["high_systolic_blood_pressure"]["maximum"],
             np.inf,
         ]
 

--- a/src/vivarium_nih_us_cvd/constants/data_keys.py
+++ b/src/vivarium_nih_us_cvd/constants/data_keys.py
@@ -181,6 +181,9 @@ class __HighSBP(NamedTuple):
     DISTRIBUTION: TargetString = TargetString(
         "risk_factor.high_systolic_blood_pressure.distribution"
     )
+    CATEGORICAL_DISTRIBUTION: TargetString = TargetString(
+        "risk_factor.categorical_high_systolic_blood_pressure.distribution"
+    )
     EXPOSURE_MEAN: TargetString = TargetString(
         "risk_factor.high_systolic_blood_pressure.exposure"
     )

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -876,5 +876,6 @@ def load_medication_adherence_exposure(key: str, location: str) -> pd.DataFrame:
 def load_dichotomous_distribution(key: str, location: str) -> str:
     return "dichotomous"
 
+
 def load_ordered_polytomous_distribution(key: str, location: str) -> str:
     return "ordered_polytomous"

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -113,6 +113,7 @@ def get_data(lookup_key: Union[str, data_keys.SourceTarget], location: str) -> p
         data_keys.LDL_C.MEDICATION_EFFECT: load_ldlc_medication_effect,
         # Risk (systolic blood pressure)
         data_keys.SBP.DISTRIBUTION: load_metadata,
+        data_keys.SBP.CATEGORICAL_DISTRIBUTION: load_ordered_polytomous_distribution,
         data_keys.SBP.EXPOSURE_MEAN: load_standard_data,
         data_keys.SBP.EXPOSURE_SD: load_standard_data,
         data_keys.SBP.EXPOSURE_WEIGHTS: load_standard_data,
@@ -874,3 +875,6 @@ def load_medication_adherence_exposure(key: str, location: str) -> pd.DataFrame:
 
 def load_dichotomous_distribution(key: str, location: str) -> str:
     return "dichotomous"
+
+def load_ordered_polytomous_distribution(key: str, location: str) -> str:
+    return "ordered_polytomous"

--- a/src/vivarium_nih_us_cvd/model_specifications/heart_failure_pafs.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/heart_failure_pafs.yaml
@@ -4,29 +4,21 @@ components:
             - BasePopulation()
         metrics:
             - ResultsStratifier()
-        risks:
-            - Risk("risk_factor.sbp_medication_adherence")
-            - Risk("risk_factor.ldlc_medication_adherence")
-            - Risk("risk_factor.outreach")
-            - Risk("risk_factor.polypill")
 
     vivarium_nih_us_cvd:
         components:
-            - IschemicStroke()
             # heart failure
             - IschemicHeartDiseaseAndHeartFailure()
             # risks
-            - AdjustedRisk("risk_factor.high_systolic_blood_pressure")
+            - TruncatedRisk("risk_factor.high_systolic_blood_pressure")
             - CategoricalSBPRisk()
             - TruncatedRisk("risk_factor.high_body_mass_index_in_adults")
-            - AdjustedRisk("risk_factor.high_ldl_cholesterol")
             # risk effects
             - PAFCalculationRiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
             - PAFCalculationRiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_residual.incidence_rate")
             - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
             - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_residual.incidence_rate")
 
-            - HealthcareUtilization()  # NOTE: this uses Treatment() as a sub-component
             # PAF observers
             - PAFObserver("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_residual.incidence_rate")
             - PAFObserver("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_residual.incidence_rate")
@@ -59,17 +51,11 @@ configuration:
         step_size: 28 # Days
     population:
         population_size: 100_000
-        age_start: 15
-        age_end: 20
-        exit_age: 20
+        age_start: 7
+        age_end: 125
+        exit_age: 125
     stratification:
         default: ['sex', 'age_group']
         high_body_mass_index_in_adults_paf:
             exclude: []
             include: []
-    outreach:
-        exposure: 0
-    polypill:
-        exposure: 0
-    intervention:
-        scenario: "baseline"

--- a/src/vivarium_nih_us_cvd/model_specifications/heart_failure_pafs.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/heart_failure_pafs.yaml
@@ -1,0 +1,75 @@
+components:
+    vivarium_public_health:
+        population:
+            - BasePopulation()
+        metrics:
+            - ResultsStratifier()
+        risks:
+            - Risk("risk_factor.sbp_medication_adherence")
+            - Risk("risk_factor.ldlc_medication_adherence")
+            - Risk("risk_factor.outreach")
+            - Risk("risk_factor.polypill")
+
+    vivarium_nih_us_cvd:
+        components:
+            - IschemicStroke()
+            # heart failure
+            - IschemicHeartDiseaseAndHeartFailure()
+            # risks
+            - AdjustedRisk("risk_factor.high_systolic_blood_pressure")
+            - CategoricalSBPRisk()
+            - TruncatedRisk("risk_factor.high_body_mass_index_in_adults")
+            - AdjustedRisk("risk_factor.high_ldl_cholesterol")
+            # risk effects
+            - PAFCalculationRiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_residual.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_residual.incidence_rate")
+
+            - HealthcareUtilization()  # NOTE: this uses Treatment() as a sub-component
+            # PAF observers
+            - PAFObserver("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_residual.incidence_rate")
+            - PAFObserver("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_residual.incidence_rate")
+
+configuration:
+    input_data:
+        input_draw_number: 0
+        location: 'Alabama'
+        artifact_path: '/home/hussain-jafari/artifacts/alabama.hdf'
+    interpolation:
+        order: 0
+        extrapolate: True
+    randomness:
+        map_size: 1_000_000
+        key_columns: ['entrance_time', 'age']
+        random_seed: 0
+    time:
+        start:
+            year: 2021 # Includes two years for burn-in
+            month: 1
+            day: 1
+        observation_start: # TODO: Implement for all observers (currently only custom observers)
+            year: 2021
+            month: 1
+            day: 1
+        end:
+            year: 2021
+            month: 1
+            day: 2
+        step_size: 28 # Days
+    population:
+        population_size: 100_000
+        age_start: 15
+        age_end: 20
+        exit_age: 20
+    stratification:
+        default: ['sex', 'age_group']
+        high_body_mass_index_in_adults_paf:
+            exclude: []
+            include: []
+    outreach:
+        exposure: 0
+    polypill:
+        exposure: 0
+    intervention:
+        scenario: "baseline"

--- a/src/vivarium_nih_us_cvd/model_specifications/heart_failure_pafs.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/heart_failure_pafs.yaml
@@ -56,6 +56,3 @@ configuration:
         exit_age: 125
     stratification:
         default: ['sex', 'age_group']
-        high_body_mass_index_in_adults_paf:
-            exclude: []
-            include: []


### PR DESCRIPTION
## Define PAF model spec

### Description
- *Category*: model spec
- *JIRA issue*: [MIC-3823](https://jira.ihme.washington.edu/browse/MIC-3823)

### Changes and notes
Defining minimal model specification to calculate PAFs. Some other changes which came up:

- subclass RiskEffect to not get PAF data
- define configuration defaults in categorical SBP exposure
- widen start and end bins for converting continuous sbp to categorical
- add categorical sbp distribution to artifact

### Verification and Testing
Ran PAF model and checked that PAFs looked reasonable (less than 1, 0 for expected demographic groups).