### PR TITLE
Create lifestyle intervention eligibility exposure

### DIFF
--- a/src/vivarium_nih_us_cvd/components/risks.py
+++ b/src/vivarium_nih_us_cvd/components/risks.py
@@ -6,9 +6,9 @@ from vivarium_public_health.risks.base_risk import Risk
 from vivarium_public_health.risks.data_transformations import (
     get_exposure_post_processor,
 )
+from vivarium_public_health.utilities import EntityString
 
 from vivarium_nih_us_cvd.constants.data_values import COLUMNS, RISK_EXPOSURE_LIMITS
-from vivarium_public_health.utilities import EntityString
 
 
 class DropValueRisk(Risk):
@@ -48,9 +48,10 @@ class DropValueRisk(Risk):
 
     def get_drop_value_post_processor(self, builder: Builder, risk: EntityString):
         drop_value_pipeline = builder.value.get_value(self.drop_value_pipeline_name)
+
         def post_processor(exposure, _):
             drop_values = drop_value_pipeline(exposure.index)
-            return (exposure - drop_values)
+            return exposure - drop_values
 
         return post_processor
 

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -13,6 +13,7 @@ components:
             - Risk("risk_factor.ldlc_medication_adherence")
             - Risk("risk_factor.outreach")
             - Risk("risk_factor.polypill")
+            - Risk("risk_factor.lifestyle_intervention_eligibility")
 
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
@@ -112,6 +113,8 @@ configuration:
         exposure: 0
     polypill:
         exposure: 0
+    lifestyle_intervention_eligibility:
+        exposure: .0855
     intervention:
         scenario: "baseline"
     outreach_scale_up: 

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -14,7 +14,7 @@ components:
             # these exposures are the percentage of eligible simulants who get enrolled
             - Risk("risk_factor.outreach")
             - Risk("risk_factor.polypill")
-            - Risk("risk_factor.lifestyle_intervention")
+            - Risk("risk_factor.lifestyle")
 
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
@@ -114,7 +114,7 @@ configuration:
         exposure: 0
     polypill:
         exposure: 0
-    lifestyle_intervention:
+    lifestyle:
         exposure: .0855
     intervention:
         scenario: "baseline"

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -11,9 +11,10 @@ components:
         risks:
             - Risk("risk_factor.sbp_medication_adherence")
             - Risk("risk_factor.ldlc_medication_adherence")
+            # these exposures are the percentage of eligible simulants who get enrolled
             - Risk("risk_factor.outreach")
             - Risk("risk_factor.polypill")
-            - Risk("risk_factor.lifestyle_intervention_eligibility")
+            - Risk("risk_factor.lifestyle_intervention")
 
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
@@ -113,7 +114,7 @@ configuration:
         exposure: 0
     polypill:
         exposure: 0
-    lifestyle_intervention_eligibility:
+    lifestyle_intervention:
         exposure: .0855
     intervention:
         scenario: "baseline"


### PR DESCRIPTION
## Create lifestyle intervention eligibility exposure

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3898](https://jira.ihme.washington.edu/browse/MIC-3898)
- *Research reference*: [Baseline coverage](https://vivarium-research.readthedocs.io/en/latest/models/intervention_models/crm_mgmt/vivarium_lifestyle.html#baseline-coverage-and-scenarios)

### Changes and notes
Create a risk for lifestyle intervention enrollment given eligibility and define baseline value.

### Verification and Testing
Checked exposure pipeline values in an interactive sim and confirmed that the proportion was around the baseline we want (8.55%).