### PR TITLE
initialize lifestyle columns

### DIFF
--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -289,7 +289,7 @@ class Treatment:
         starting_event_time = self.clock()
         fpg_test_start_time = starting_event_time
         # Subtract step size until we reach the first day less than or equal to 3 years before our sim starting event date
-        while fpg_test_start_time > starting_event_time - pd.DateOffset(
+        while fpg_test_start_time >= starting_event_time - pd.DateOffset(
             years=data_values.FPG_TESTING.NUM_YEARS_BEFORE_SIM_START
         ):
             fpg_test_start_time = fpg_test_start_time - self.step_size()

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -285,11 +285,17 @@ class Treatment:
         )
 
         # sample from dates uniformly distributed from 0 to 3 years before sim start date
-        draws = self.randomness.get_draw(index=simulants_with_test_date.index, additional_key='fpg_test_date')
-        time_before_event_start = draws * pd.Timedelta(days=365.25*data_values.FPG_TESTING.NUM_YEARS_BEFORE_SIM_START)
+        draws = self.randomness.get_draw(
+            index=simulants_with_test_date.index, additional_key="fpg_test_date"
+        )
+        time_before_event_start = draws * pd.Timedelta(
+            days=365.25 * data_values.FPG_TESTING.NUM_YEARS_BEFORE_SIM_START
+        )
 
         fpg_test_date_column = pd.Series(pd.NaT, index=pop.index)
-        fpg_test_date_column[simulants_with_test_date.index] = self.clock() + pd.Timedelta(days=28) - time_before_event_start
+        fpg_test_date_column[simulants_with_test_date.index] = (
+            self.clock() + pd.Timedelta(days=28) - time_before_event_start
+        )
         pop[data_values.COLUMNS.LAST_FPG_TEST_DATE] = fpg_test_date_column
 
         # Generate multiplier columns

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -22,6 +22,8 @@ class __Columns(NamedTuple):
     LDLC_MULTIPLIER: str = "ldlc_multiplier"
     OUTREACH: str = "outreach"
     POLYPILL: str = "polypill"
+    LIFESTYLE: str = "lifestyle"
+    LAST_FPG_TEST_DATE: str = 'last_fpg_test_date'
 
     @property
     def name(self):
@@ -47,6 +49,8 @@ class __Pipelines(NamedTuple):
     LDLC_MEDICATION_ADHERENCE_EXPOSURE: str = "ldlc_medication_adherence.exposure"
     OUTREACH_EXPOSURE: str = "outreach.exposure"
     POLYPILL_EXPOSURE: str = "polypill.exposure"
+    LIFESTYLE_EXPOSURE: str = "lifestyle.exposure"
+    BMI_EXPOSURE: str = "high_body_mass_index_in_adults.exposure"
 
     @property
     def name(self):
@@ -489,7 +493,7 @@ class __OutreachEffectSBP(NamedTuple):
 
     @property
     def name(self):
-        return "sbp_multiplier"
+        return "outreach_effect_sbp"
 
 
 OUTREACH_EFFECT_SBP = __OutreachEffectSBP()
@@ -504,10 +508,26 @@ class __OutreachEffectLDLC(NamedTuple):
 
     @property
     def name(self):
-        return "sbp_multiplier"
+        return "outreach_effect_ldl"
 
 
 OUTREACH_EFFECT_LDLC = __OutreachEffectLDLC()
+
+
+class __FPGTesting(NamedTuple):
+    """parameters related to FPG testing"""
+
+    BMI_ELIGIBILITY_THRESHOLD: float = 25.0
+    AGE_ELIGIBILITY_THRESHOLD: float = 35.0
+    PROBABILITY_OF_TESTING_GIVEN_ELIGIBLE: float = .71
+    NUM_YEARS_BEFORE_SIM_START: int = 3
+
+    @property
+    def name(self):
+        return "fpg_testing"
+
+
+FPG_TESTING = __FPGTesting()
 
 
 # Define the outreach effects on primary_non_adherence (cat 1) levels

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -23,7 +23,7 @@ class __Columns(NamedTuple):
     OUTREACH: str = "outreach"
     POLYPILL: str = "polypill"
     LIFESTYLE: str = "lifestyle"
-    LAST_FPG_TEST_DATE: str = 'last_fpg_test_date'
+    LAST_FPG_TEST_DATE: str = "last_fpg_test_date"
 
     @property
     def name(self):
@@ -519,7 +519,7 @@ class __FPGTesting(NamedTuple):
 
     BMI_ELIGIBILITY_THRESHOLD: float = 25.0
     AGE_ELIGIBILITY_THRESHOLD: float = 35.0
-    PROBABILITY_OF_TESTING_GIVEN_ELIGIBLE: float = .71
+    PROBABILITY_OF_TESTING_GIVEN_ELIGIBLE: float = 0.71
     NUM_YEARS_BEFORE_SIM_START: int = 3
 
     @property

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -70,8 +70,7 @@ configuration:
     input_data:
         input_draw_number: 0
         location: 'Alabama'
-        #artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
-        artifact_path: '/home/hussain-jafari/artifacts/alabama.hdf'
+        artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -13,6 +13,7 @@ components:
             - Risk("risk_factor.ldlc_medication_adherence")
             - Risk("risk_factor.outreach")
             - Risk("risk_factor.polypill")
+            - Risk("risk_factor.lifestyle")
 
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
             - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
@@ -69,7 +70,8 @@ configuration:
     input_data:
         input_draw_number: 0
         location: 'Alabama'
-        artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
+        #artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
+        artifact_path: '/home/hussain-jafari/artifacts/alabama.hdf'
     interpolation:
         order: 0
         extrapolate: True
@@ -112,6 +114,8 @@ configuration:
         exposure: 0
     polypill:
         exposure: 0
+    lifestyle:
+        exposure: .0855
     intervention:
         scenario: "baseline"
     outreach_scale_up: 


### PR DESCRIPTION
## initialize lifestyle columns

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3897](https://jira.ihme.washington.edu/browse/MIC-3897)
- *Research reference*: [Last FPG test initialization](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_us_cvd/concept_model.html#initialization-parameters)

### Verification and Testing
In an interactive context at initialization, checked that lifestyle column was NaT and that last FPG test had the right bounds, dates for 71% of eligible simulants, and that these dates were roughly uniformly distributed. 