### PR TITLE
enroll in lifestyle

### DIFF
--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -883,8 +883,12 @@ class Treatment:
         fpg = self.fpg(tested_simulants.index)
 
         # Enroll in lifestyle by updating lifestyle column with date of enrollment
-        fpg_within_bounds = (fpg >= data_values.FPG_TESTING.LOWER_ENROLLMENT_BOUND) & (fpg <= data_values.FPG_TESTING.UPPER_ENROLLMENT_BOUND)
-        enroll_if_fpg_within_bounds = self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
+        fpg_within_bounds = (fpg >= data_values.FPG_TESTING.LOWER_ENROLLMENT_BOUND) & (
+            fpg <= data_values.FPG_TESTING.UPPER_ENROLLMENT_BOUND
+        )
+        enroll_if_fpg_within_bounds = (
+            self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
+        )
         newly_enrolled = fpg_within_bounds & enroll_if_fpg_within_bounds
         tested_simulants.loc[newly_enrolled, data_values.COLUMNS.LIFESTYLE] = self.clock()
 
@@ -902,7 +906,6 @@ class Treatment:
                 ]
             ]
         )
-
 
     def get_measured_sbp(
         self,

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -881,8 +881,12 @@ class Treatment:
         ] = self.clock()
 
         fpg = self.fpg(tested_simulants.index)
+
+        # Enroll in lifestyle by updating lifestyle column with date of enrollment
         fpg_within_bounds = (fpg >= data_values.FPG_TESTING.LOWER_ENROLLMENT_BOUND) & (fpg <= data_values.FPG_TESTING.UPPER_ENROLLMENT_BOUND)
-        enroll_if_eligible = self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
+        enroll_if_fpg_within_bounds = self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
+        newly_enrolled = fpg_within_bounds & enroll_if_fpg_within_bounds
+        tested_simulants.loc[newly_enrolled, data_values.COLUMNS.LIFESTYLE] = self.clock()
 
         self.population_view.update(
             pop_visitors[
@@ -891,6 +895,14 @@ class Treatment:
                 ]
             ]
         )
+        self.population_view.update(
+            tested_simulants[
+                [
+                    data_values.COLUMNS.LIFESTYLE,
+                ]
+            ]
+        )
+
 
     def get_measured_sbp(
         self,

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -560,8 +560,8 @@ class __FPGTesting(NamedTuple):
     AGE_ELIGIBILITY_THRESHOLD: float = 35.0
     PROBABILITY_OF_TESTING_GIVEN_ELIGIBLE: float = 0.71
     MIN_YEARS_BETWEEN_TESTS: int = 3
-    LOWER_ENROLLMENT_BOUND: int = 100
-    UPPER_ENROLLMENT_BOUND: int = 126
+    LOWER_ENROLLMENT_BOUND: float = 5.6
+    UPPER_ENROLLMENT_BOUND: float = 7.0
 
     @property
     def name(self):

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -574,8 +574,8 @@ FPG_TESTING = __FPGTesting()
 class __LifestyleExposure(NamedTuple):
     """exposure categories for lifestyle intervention"""
 
-    EXPOSED: float = 'cat1'
-    UNEXPOSED: float = 'cat2'
+    EXPOSED: float = "cat1"
+    UNEXPOSED: float = "cat2"
 
     @property
     def name(self):

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -51,6 +51,7 @@ class __Pipelines(NamedTuple):
     POLYPILL_EXPOSURE: str = "polypill.exposure"
     LIFESTYLE_EXPOSURE: str = "lifestyle.exposure"
     BMI_EXPOSURE: str = "high_body_mass_index_in_adults.exposure"
+    FPG_EXPOSURE: str = "high_fasting_plasma_glucose.exposure"
 
     @property
     def name(self):
@@ -559,6 +560,8 @@ class __FPGTesting(NamedTuple):
     AGE_ELIGIBILITY_THRESHOLD: float = 35.0
     PROBABILITY_OF_TESTING_GIVEN_ELIGIBLE: float = 0.71
     MIN_YEARS_BETWEEN_TESTS: int = 3
+    LOWER_ENROLLMENT_BOUND: int = 100
+    UPPER_ENROLLMENT_BOUND: int = 126
 
     @property
     def name(self):
@@ -566,6 +569,20 @@ class __FPGTesting(NamedTuple):
 
 
 FPG_TESTING = __FPGTesting()
+
+
+class __LifestyleExposure(NamedTuple):
+    """exposure categories for lifestyle intervention"""
+
+    EXPOSED: float = 'cat1'
+    UNEXPOSED: float = 'cat2'
+
+    @property
+    def name(self):
+        return "lifestyle_exposure"
+
+
+LIFESTYLE_EXPOSURE = __LifestyleExposure()
 
 
 # Define the outreach effects on primary_non_adherence (cat 1) levels


### PR DESCRIPTION
## enroll in lifestyle

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3901](https://jira.ihme.washington.edu/browse/MIC-3901)
- *Research reference*: [lifestyle intervention ramp](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_us_cvd/concept_model.html#healthcare-system-modeling)

### Verification and Testing
Ran an interactive sim and checked that simulants were having their lifestyle column updated with the current clock time and that their FPG values were within the expected bounds. Also checked that we had (roughly) the expected ratio of enrolled simulants given they were eligible. 