### PR TITLE
Feature/schedule lifestyle followup

### DIFF
--- a/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
+++ b/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
@@ -259,15 +259,21 @@ class HealthcareUtilization:
         # Test FPG and enroll in lifestyle
         all_visitors = visit_emergency.union(visit_scheduled).union(visit_background)
         tested_simulants = self.test_fpg(pop_visitors=pop.loc[all_visitors])
-        newly_lifestyle_enrolled_simulants = self.determine_lifestyle_enrollment(tested_simulants=tested_simulants)
+        newly_lifestyle_enrolled_simulants = self.determine_lifestyle_enrollment(
+            tested_simulants=tested_simulants
+        )
         breakpoint()
 
         pop.loc[tested_simulants.index, data_values.COLUMNS.LAST_FPG_TEST_DATE] = self.clock()
-        pop.loc[newly_lifestyle_enrolled_simulants, data_values.COLUMNS.LIFESTYLE] = self.clock()
+        pop.loc[
+            newly_lifestyle_enrolled_simulants, data_values.COLUMNS.LIFESTYLE
+        ] = self.clock()
 
         # Schedule followups
         needs_followup_sbp = self.determine_followups_sbp(pop_visitors=pop.loc[all_visitors])
-        needs_followup_ldlc = self.determine_followups_ldlc(pop_visitors=pop.loc[all_visitors])
+        needs_followup_ldlc = self.determine_followups_ldlc(
+            pop_visitors=pop.loc[all_visitors]
+        )
         # Do not schedule a followup if one already exists
         has_followup_already_scheduled = pop[
             (pop[data_values.COLUMNS.SCHEDULED_VISIT_DATE] > event_time)
@@ -373,7 +379,7 @@ class HealthcareUtilization:
             fpg <= data_values.FPG_TESTING.UPPER_ENROLLMENT_BOUND
         )
         enroll_if_fpg_within_bounds = (
-                self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
+            self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
         )
         newly_enrolled = fpg_within_bounds & enroll_if_fpg_within_bounds
 

--- a/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
+++ b/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
@@ -360,9 +360,17 @@ class HealthcareUtilization:
         visitors_high_ldlc = visitors.intersection(
             measured_ldlc[measured_ldlc >= data_values.LDLC_THRESHOLD.LOW].index
         )
-
-        # Schedule those with high ldlc and high ASCVD
-        needs_followup = visitors_high_ascvd.intersection(visitors_high_ldlc)
+        visitors_on_ldlc_medication = visitors.intersection(
+            pop_visitors[
+                pop_visitors[data_values.COLUMNS.LDLC_MEDICATION]
+                != data_values.LDLC_MEDICATION_LEVEL.NO_TREATMENT.DESCRIPTION
+            ].index
+        )
+        # Schedule those on ldlc medication and have high ldlc or those not on
+        # ldlc medication but have high ASCVD and ldlc
+        needs_followup = (
+            visitors_on_ldlc_medication.union(visitors_high_ascvd)
+        ).intersection(visitors_high_ldlc)
 
         return needs_followup
 

--- a/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
+++ b/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
@@ -380,8 +380,6 @@ class HealthcareUtilization:
         enroll_if_fpg_within_bounds = (
             self.lifestyle(pop_visitors.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
         )
-
-        # Enroll in lifestyle by updating enrollment date
         newly_enrolled = (
             (tested_this_step) & (fpg_within_bounds) & (enroll_if_fpg_within_bounds)
         )

--- a/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
+++ b/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
@@ -262,7 +262,6 @@ class HealthcareUtilization:
         newly_lifestyle_enrolled_simulants = self.determine_lifestyle_enrollment(
             tested_simulants=tested_simulants
         )
-        breakpoint()
 
         pop.loc[tested_simulants.index, data_values.COLUMNS.LAST_FPG_TEST_DATE] = self.clock()
         pop.loc[

--- a/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
+++ b/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
@@ -191,10 +191,13 @@ class HealthcareUtilization:
         pop[data_values.COLUMNS.LAST_FPG_TEST_DATE] = fpg_test_date_column
 
         self.population_view.update(
-            pop[[data_values.COLUMNS.VISIT_TYPE,
-                 data_values.COLUMNS.SCHEDULED_VISIT_DATE,
-                 data_values.COLUMNS.LAST_FPG_TEST_DATE,
-                 ]]
+            pop[
+                [
+                    data_values.COLUMNS.VISIT_TYPE,
+                    data_values.COLUMNS.SCHEDULED_VISIT_DATE,
+                    data_values.COLUMNS.LAST_FPG_TEST_DATE,
+                ]
+            ]
         )
 
     def on_time_step_cleanup(self, event: Event) -> None:
@@ -257,7 +260,9 @@ class HealthcareUtilization:
         all_visitors = visit_emergency.union(visit_scheduled).union(visit_background)
         # Get pop visitors with updated test date and update population view
         pop_visitors = self.test_fpg(pop_visitors=pop.loc[all_visitors])
-        needs_followup_lifestyle = self.determine_followups_lifestyle(pop_visitors=pop_visitors)
+        needs_followup_lifestyle = self.determine_followups_lifestyle(
+            pop_visitors=pop_visitors
+        )
 
         needs_followup_sbp = self.determine_followups_sbp(pop_visitors=pop_visitors)
         needs_followup_ldlc = self.determine_followups_ldlc(pop_visitors=pop_visitors)
@@ -266,9 +271,9 @@ class HealthcareUtilization:
             (pop[data_values.COLUMNS.SCHEDULED_VISIT_DATE] > event_time)
         ].index
 
-        to_schedule_followup = needs_followup_lifestyle.union((needs_followup_sbp.union(needs_followup_ldlc))).difference(
-            has_followup_already_scheduled
-        )
+        to_schedule_followup = needs_followup_lifestyle.union(
+            (needs_followup_sbp.union(needs_followup_ldlc))
+        ).difference(has_followup_already_scheduled)
         pop.loc[
             to_schedule_followup, data_values.COLUMNS.SCHEDULED_VISIT_DATE
         ] = self.schedule_followup(index=to_schedule_followup, event_time=event_time)
@@ -363,7 +368,9 @@ class HealthcareUtilization:
 
     def determine_followups_lifestyle(self, pop_visitors: pd.DataFrame) -> pd.Index:
         """Apply lifestyle intervention ramp logic to determine who gets scheduled a followup"""
-        tested_this_step = pop_visitors[data_values.COLUMNS.LAST_FPG_TEST_DATE] == self.clock()
+        tested_this_step = (
+            pop_visitors[data_values.COLUMNS.LAST_FPG_TEST_DATE] == self.clock()
+        )
 
         # FPG related ramping
         fpg = self.fpg(pop_visitors.index)
@@ -375,7 +382,9 @@ class HealthcareUtilization:
         )
 
         # Enroll in lifestyle by updating enrollment date
-        newly_enrolled = (tested_this_step) & (fpg_within_bounds) & (enroll_if_fpg_within_bounds)
+        newly_enrolled = (
+            (tested_this_step) & (fpg_within_bounds) & (enroll_if_fpg_within_bounds)
+        )
 
         return pop_visitors[newly_enrolled].index
 

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -468,7 +468,6 @@ class Treatment:
             pop.loc[visitors] = self.enroll_in_polypill(
                 pop_visitors=pop.loc[visitors], maybe_enroll=maybe_enroll_sbp
             )
-
         # Move through lifestyle intervention ramp
         self.apply_lifestyle_ramp(pop_visitors=pop.loc[visitors])
 
@@ -816,7 +815,7 @@ class Treatment:
 
     def apply_lifestyle_ramp(self, pop_visitors: pd.DataFrame) -> pd.DataFrame:
         # Find which simulants got their FPG tested by healthcare component this step
-        tested_this_step = pop_visitors.loc[data_values.COLUMNS.LAST_FPG_TEST_DATE] = self.clock()
+        tested_this_step = pop_visitors[data_values.COLUMNS.LAST_FPG_TEST_DATE] == self.clock()
 
         # FPG related ramping
         fpg = self.fpg(pop_visitors.index)

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -883,8 +883,12 @@ class Treatment:
         fpg = self.fpg(tested_simulants.index)
 
         # Enroll in lifestyle by updating lifestyle column with date of enrollment
-        fpg_within_bounds = (fpg >= data_values.FPG_TESTING.LOWER_ENROLLMENT_BOUND) & (fpg <= data_values.FPG_TESTING.UPPER_ENROLLMENT_BOUND)
-        enroll_if_fpg_within_bounds = self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
+        fpg_within_bounds = (fpg >= data_values.FPG_TESTING.LOWER_ENROLLMENT_BOUND) & (
+            fpg <= data_values.FPG_TESTING.UPPER_ENROLLMENT_BOUND
+        )
+        enroll_if_fpg_within_bounds = (
+            self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
+        )
         newly_enrolled = fpg_within_bounds & enroll_if_fpg_within_bounds
         tested_simulants.loc[newly_enrolled, data_values.COLUMNS.LIFESTYLE] = self.clock()
 
@@ -902,7 +906,6 @@ class Treatment:
                 ]
             ]
         )
-
 
     def get_measured_sbp(
         self,

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -814,7 +814,9 @@ class Treatment:
 
     def apply_lifestyle_ramp(self, pop_visitors: pd.DataFrame) -> pd.DataFrame:
         # Find which simulants got their FPG tested by healthcare component this step
-        tested_this_step = pop_visitors[data_values.COLUMNS.LAST_FPG_TEST_DATE] == self.clock()
+        tested_this_step = (
+            pop_visitors[data_values.COLUMNS.LAST_FPG_TEST_DATE] == self.clock()
+        )
 
         # FPG related ramping
         fpg = self.fpg(pop_visitors.index)
@@ -826,7 +828,9 @@ class Treatment:
         )
 
         # Enroll in lifestyle by updating enrollment date
-        newly_enrolled = (tested_this_step) & (fpg_within_bounds) & (enroll_if_fpg_within_bounds)
+        newly_enrolled = (
+            (tested_this_step) & (fpg_within_bounds) & (enroll_if_fpg_within_bounds)
+        )
         pop_visitors.loc[newly_enrolled, data_values.COLUMNS.LIFESTYLE] = self.clock()
 
         self.population_view.update(

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -467,8 +467,7 @@ class Treatment:
             pop.loc[visitors] = self.enroll_in_polypill(
                 pop_visitors=pop.loc[visitors], maybe_enroll=maybe_enroll_sbp
             )
-        # Move through lifestyle intervention ramp
-        self.apply_lifestyle_ramp(pop_visitors=pop.loc[visitors])
+        self.enroll_in_lifestyle(pop_visitors=pop.loc[visitors])
 
         self.population_view.update(
             pop[
@@ -812,7 +811,7 @@ class Treatment:
 
         return pop_visitors
 
-    def apply_lifestyle_ramp(self, pop_visitors: pd.DataFrame) -> pd.DataFrame:
+    def enroll_in_lifestyle(self, pop_visitors: pd.DataFrame) -> pd.DataFrame:
         # Find which simulants got their FPG tested by healthcare component this step
         tested_this_step = (
             pop_visitors[data_values.COLUMNS.LAST_FPG_TEST_DATE] == self.clock()
@@ -836,7 +835,6 @@ class Treatment:
         self.population_view.update(
             pop_visitors[
                 [
-                    data_values.COLUMNS.LAST_FPG_TEST_DATE,
                     data_values.COLUMNS.LIFESTYLE,
                 ]
             ]

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -881,8 +881,12 @@ class Treatment:
         ] = self.clock()
 
         fpg = self.fpg(tested_simulants.index)
+
+        # Enroll in lifestyle by updating lifestyle column with date of enrollment
         fpg_within_bounds = (fpg >= data_values.FPG_TESTING.LOWER_ENROLLMENT_BOUND) & (fpg <= data_values.FPG_TESTING.UPPER_ENROLLMENT_BOUND)
-        enroll_if_eligible = self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
+        enroll_if_fpg_within_bounds = self.lifestyle(tested_simulants.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
+        newly_enrolled = fpg_within_bounds & enroll_if_fpg_within_bounds
+        tested_simulants.loc[newly_enrolled, data_values.COLUMNS.LIFESTYLE] = self.clock()
 
         self.population_view.update(
             pop_visitors[
@@ -891,6 +895,14 @@ class Treatment:
                 ]
             ]
         )
+        self.population_view.update(
+            tested_simulants[
+                [
+                    data_values.COLUMNS.LIFESTYLE,
+                ]
+            ]
+        )
+
 
     def get_measured_sbp(
         self,

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -467,7 +467,6 @@ class Treatment:
             pop.loc[visitors] = self.enroll_in_polypill(
                 pop_visitors=pop.loc[visitors], maybe_enroll=maybe_enroll_sbp
             )
-        self.enroll_in_lifestyle(pop_visitors=pop.loc[visitors])
 
         self.population_view.update(
             pop[
@@ -810,35 +809,6 @@ class Treatment:
         )
 
         return pop_visitors
-
-    def enroll_in_lifestyle(self, pop_visitors: pd.DataFrame) -> pd.DataFrame:
-        # Find which simulants got their FPG tested by healthcare component this step
-        tested_this_step = (
-            pop_visitors[data_values.COLUMNS.LAST_FPG_TEST_DATE] == self.clock()
-        )
-
-        # FPG related ramping
-        fpg = self.fpg(pop_visitors.index)
-        fpg_within_bounds = (fpg >= data_values.FPG_TESTING.LOWER_ENROLLMENT_BOUND) & (
-            fpg <= data_values.FPG_TESTING.UPPER_ENROLLMENT_BOUND
-        )
-        enroll_if_fpg_within_bounds = (
-            self.lifestyle(pop_visitors.index) == data_values.LIFESTYLE_EXPOSURE.EXPOSED
-        )
-
-        # Enroll in lifestyle by updating enrollment date
-        newly_enrolled = (
-            (tested_this_step) & (fpg_within_bounds) & (enroll_if_fpg_within_bounds)
-        )
-        pop_visitors.loc[newly_enrolled, data_values.COLUMNS.LIFESTYLE] = self.clock()
-
-        self.population_view.update(
-            pop_visitors[
-                [
-                    data_values.COLUMNS.LIFESTYLE,
-                ]
-            ]
-        )
 
     def get_measured_sbp(
         self,

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -41,7 +41,6 @@ class Treatment:
         self.outreach = builder.value.get_value(data_values.PIPELINES.OUTREACH_EXPOSURE)
         self.polypill = builder.value.get_value(data_values.PIPELINES.POLYPILL_EXPOSURE)
         self.lifestyle = builder.value.get_value(data_values.PIPELINES.LIFESTYLE_EXPOSURE)
-        self.bmi = builder.value.get_value(data_values.PIPELINES.BMI_EXPOSURE)
         self.fpg = builder.value.get_value(data_values.PIPELINES.FPG_EXPOSURE)
 
         self.sbp_treatment_map = self._get_sbp_treatment_map()

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -560,8 +560,8 @@ class __FPGTesting(NamedTuple):
     AGE_ELIGIBILITY_THRESHOLD: float = 35.0
     PROBABILITY_OF_TESTING_GIVEN_ELIGIBLE: float = 0.71
     MIN_YEARS_BETWEEN_TESTS: int = 3
-    LOWER_ENROLLMENT_BOUND: int = 100
-    UPPER_ENROLLMENT_BOUND: int = 126
+    LOWER_ENROLLMENT_BOUND: float = 5.6
+    UPPER_ENROLLMENT_BOUND: float = 7.0
 
     @property
     def name(self):

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -574,8 +574,8 @@ FPG_TESTING = __FPGTesting()
 class __LifestyleExposure(NamedTuple):
     """exposure categories for lifestyle intervention"""
 
-    EXPOSED: float = 'cat1'
-    UNEXPOSED: float = 'cat2'
+    EXPOSED: float = "cat1"
+    UNEXPOSED: float = "cat2"
 
     @property
     def name(self):

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -51,6 +51,7 @@ class __Pipelines(NamedTuple):
     POLYPILL_EXPOSURE: str = "polypill.exposure"
     LIFESTYLE_EXPOSURE: str = "lifestyle.exposure"
     BMI_EXPOSURE: str = "high_body_mass_index_in_adults.exposure"
+    FPG_EXPOSURE: str = "high_fasting_plasma_glucose.exposure"
 
     @property
     def name(self):
@@ -559,6 +560,8 @@ class __FPGTesting(NamedTuple):
     AGE_ELIGIBILITY_THRESHOLD: float = 35.0
     PROBABILITY_OF_TESTING_GIVEN_ELIGIBLE: float = 0.71
     MIN_YEARS_BETWEEN_TESTS: int = 3
+    LOWER_ENROLLMENT_BOUND: int = 100
+    UPPER_ENROLLMENT_BOUND: int = 126
 
     @property
     def name(self):
@@ -566,6 +569,20 @@ class __FPGTesting(NamedTuple):
 
 
 FPG_TESTING = __FPGTesting()
+
+
+class __LifestyleExposure(NamedTuple):
+    """exposure categories for lifestyle intervention"""
+
+    EXPOSED: float = 'cat1'
+    UNEXPOSED: float = 'cat2'
+
+    @property
+    def name(self):
+        return "lifestyle_exposure"
+
+
+LIFESTYLE_EXPOSURE = __LifestyleExposure()
 
 
 # Define the outreach effects on primary_non_adherence (cat 1) levels


### PR DESCRIPTION
## Schedule lifestyle followup

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3902](https://jira.ihme.washington.edu/browse/MIC-3902)
- *Research reference*: [lifestyle intervention ramp](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_us_cvd/concept_model.html#healthcare-system-modeling)

### Changes and notes
Initialize last FPG test date and update last FPG test date on timestep cleanup in healthcare utilization component rather than treatment because of component ordering. Some changes to lifestyle ramp in treatment as a result of this.  

### Verification and Testing
Checked for two timesteps in an interactive context that simulants who were enrolled in lifestyle on that timestep had a scheduled followup. 