### PR TITLE
LDL ramp followup update

### DIFF
--- a/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
+++ b/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
@@ -272,17 +272,9 @@ class HealthcareUtilization:
         visitors_high_ldlc = visitors.intersection(
             measured_ldlc[measured_ldlc >= data_values.LDLC_THRESHOLD.LOW].index
         )
-        visitors_on_ldlc_medication = visitors.intersection(
-            pop_visitors[
-                pop_visitors[data_values.COLUMNS.LDLC_MEDICATION]
-                != data_values.LDLC_MEDICATION_LEVEL.NO_TREATMENT.DESCRIPTION
-            ].index
-        )
-        # Schedule those on ldlc medication and have high ldlc or those not on
-        # ldlc medication but have high ASCVD and ldlc
-        needs_followup = (
-            visitors_on_ldlc_medication.union(visitors_high_ascvd)
-        ).intersection(visitors_high_ldlc)
+
+        # Schedule those with high ldlc and high ASCVD
+        needs_followup = visitors_high_ascvd.intersection(visitors_high_ldlc)
 
         return needs_followup
 

--- a/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
+++ b/src/vivarium_nih_us_cvd/components/healthcare_utilization.py
@@ -274,6 +274,9 @@ class HealthcareUtilization:
         )
 
         # Schedule those with high ldlc and high ASCVD
+        # All simulants under these conditions get scheduled a followup in our LDL-C ramp
+        # regardless of medication status or medical history, and all simulants who don't meet
+        # both conditions do not get scheduled a followup
         needs_followup = visitors_high_ascvd.intersection(visitors_high_ldlc)
 
         return needs_followup


### PR DESCRIPTION
## LDL ramp followup update

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3983](https://jira.ihme.washington.edu/browse/MIC-3983)
- *Research reference*: [LDL-C Treatment Ramp](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_us_cvd/concept_model.html#healthcare-system-modeling)

### Changes and notes
Follows up should not be scheduled for those with low ASCVD. This is equivalent to only scheduling only those with high LDL and high ASCVD, regardless of medication status.

### Verification and Testing
Checked in an interactive context that healthcare visitors on LDL treatment with high LDL and low ASCVD were not getting new followups.