### PR TITLE
better handle existing artifact checks

### DIFF
--- a/src/vivarium_nih_us_cvd/tools/make_artifacts.py
+++ b/src/vivarium_nih_us_cvd/tools/make_artifacts.py
@@ -48,11 +48,9 @@ def check_for_existing(
         ]
     )
     locations = set([sanitize_location(loc) for loc in metadata.LOCATIONS])
+    location = sanitize_location(location)
     existing = locations.intersection(existing_artifacts)
-
-    if existing:
-        if location != "all":
-            existing = [sanitize_location(location)]
+    if existing and (location == "all" or location in existing):
         if not append:
             click.confirm(
                 f"Existing artifacts found for {existing}. Do you want to delete and rebuild?",


### PR DESCRIPTION
## Title: Bugfix better handle existing artifacts when building new ones

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4129](https://jira.ihme.washington.edu/browse/MIC-4129)

### Changes and notes
The logic here wasn't working as intended; the code would ask to delete an existing artifact
even if it isn't the location you're trying to build.

### Testing
Tested locally by running `make_artifact` and making sure it appropriately drops
into the checks for --append and --replace for the following locations:
- "all"
- a state that already has an artifact
- a state that does not have an artifact
