### PR TITLE
refactor custom cvd observers

### DIFF
--- a/src/vivarium_nih_us_cvd/components/__init__.py
+++ b/src/vivarium_nih_us_cvd/components/__init__.py
@@ -6,8 +6,8 @@ from .observers import (
     CategoricalColumnObserver,
     ContinuousRiskObserver,
     HealthcareVisitObserver,
+    LifestyleObserver,
     ResultsStratifier,
-    TransientIHDAndHFObserver,
 )
 from .risks import AdjustedRisk, CategoricalSBPRisk, TruncatedRisk
 from .treatment import Treatment

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -78,7 +78,9 @@ class ContinuousRiskObserver:
     def _get_configuration_defaults(self) -> Dict[str, Dict]:
         return {
             "stratification": {
-                self.risk: ContinuousRiskObserver.configuration_defaults["stratification"]["risk"]
+                self.risk: ContinuousRiskObserver.configuration_defaults["stratification"][
+                    "risk"
+                ]
             }
         }
 
@@ -172,6 +174,7 @@ class HealthcareVisitObserver:
                 excluded_stratifications=self.config.exclude,
                 when="collect_metrics",
             )
+
     def calculate_visit_counts(self, x: pd.DataFrame) -> int:
         return len(x)
 
@@ -263,7 +266,7 @@ class CategoricalColumnObserver:
 
 class LifestyleObserver(CategoricalColumnObserver):
     def __init__(self):
-        self.column = 'lifestyle'
+        self.column = "lifestyle"
         self.configuration_defaults = self._get_configuration_defaults()
 
     def register_observations(self, builder: Builder) -> None:
@@ -287,10 +290,10 @@ class LifestyleObserver(CategoricalColumnObserver):
         )
 
     def _get_categories(self) -> List[str]:
-        return ['cat1', 'cat2']
+        return ["cat1", "cat2"]
 
     def calculate_exposed_lifestyle_person_time(self, x: pd.DataFrame) -> float:
-        return sum(~(x['lifestyle'].isna())) * to_years(self.step_size())
+        return sum(~(x["lifestyle"].isna())) * to_years(self.step_size())
 
     def calculate_unexposed_lifestyle_person_time(self, x: pd.DataFrame) -> float:
-        return sum(x['lifestyle'].isna()) * to_years(self.step_size())
+        return sum(x["lifestyle"].isna()) * to_years(self.step_size())

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -166,7 +166,6 @@ class HealthcareVisitObserver:
             builder.results.register_observation(
                 name=f"healthcare_visits_{visit_type}",
                 pop_filter=f'alive == "alive" and visit_type == "{visit_type}"',
-                aggregator=len,
                 requires_columns=["alive", data_values.COLUMNS.VISIT_TYPE],
                 additional_stratifications=self.config.include,
                 excluded_stratifications=self.config.exclude,

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -97,7 +97,6 @@ class ContinuousRiskObserver:
     #################
 
     def setup(self, builder: Builder) -> None:
-        self.clock = builder.time.clock()
         self.step_size = builder.time.step_size()
         self.config = builder.configuration.stratification[self.risk]
 
@@ -157,7 +156,6 @@ class HealthcareVisitObserver:
     #################
 
     def setup(self, builder: Builder) -> None:
-        self.clock = builder.time.clock()
         self.step_size = builder.time.step_size()
         self.config = builder.configuration.stratification["visits"]
 
@@ -224,7 +222,6 @@ class CategoricalColumnObserver:
     #################
 
     def setup(self, builder: Builder) -> None:
-        self.clock = builder.time.clock()
         self.step_size = builder.time.step_size()
         self.config = builder.configuration.stratification[self.column]
         self.categories = self._get_categories()

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -166,15 +166,12 @@ class HealthcareVisitObserver:
             builder.results.register_observation(
                 name=f"healthcare_visits_{visit_type}",
                 pop_filter=f'alive == "alive" and visit_type == "{visit_type}"',
-                aggregator=self.calculate_visit_counts,
+                aggregator=len,
                 requires_columns=["alive", data_values.COLUMNS.VISIT_TYPE],
                 additional_stratifications=self.config.include,
                 excluded_stratifications=self.config.exclude,
                 when="collect_metrics",
             )
-
-    def calculate_visit_counts(self, x: pd.DataFrame) -> int:
-        return len(x)
 
 
 class CategoricalColumnObserver:
@@ -224,7 +221,7 @@ class CategoricalColumnObserver:
     def setup(self, builder: Builder) -> None:
         self.step_size = builder.time.step_size()
         self.config = builder.configuration.stratification[self.column]
-        self.categories = self._get_categories()
+        self.categories = self.get_categories()
 
         columns_required = ["alive", self.column]
         self.population_view = builder.population.get_view(columns_required)
@@ -243,7 +240,7 @@ class CategoricalColumnObserver:
                 when="time_step__prepare",
             )
 
-    def _get_categories(self) -> List[str]:
+    def get_categories(self) -> List[str]:
         mapping = {
             data_values.COLUMNS.SBP_MEDICATION: [
                 level.DESCRIPTION for level in data_values.SBP_MEDICATION_LEVEL
@@ -286,7 +283,7 @@ class LifestyleObserver(CategoricalColumnObserver):
             when="time_step__prepare",
         )
 
-    def _get_categories(self) -> List[str]:
+    def get_categories(self) -> List[str]:
         return ["cat1", "cat2"]
 
     def calculate_exposed_lifestyle_person_time(self, x: pd.DataFrame) -> float:

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -1,51 +1,9 @@
 components:
-    vivarium_public_health:
-        population:
-            - BasePopulation()
-            - Mortality()
-        metrics:
-            - MortalityObserver()
-            - DisabilityObserver()
-            - DiseaseObserver("ischemic_stroke")
-            - DiseaseObserver("ischemic_heart_disease_and_heart_failure")
-        risks:
-            - Risk("risk_factor.sbp_medication_adherence")
-            - Risk("risk_factor.ldlc_medication_adherence")
-            # these exposures are the percentage of eligible simulants who get enrolled
-            - Risk("risk_factor.outreach")
-            - Risk("risk_factor.polypill")
-            - Risk("risk_factor.lifestyle")
-
-            - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
-            - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
-            - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_ischemic_stroke.incidence_rate")
-            - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
-            
-            - RiskEffect("risk_factor.high_systolic_blood_pressure", "cause.acute_myocardial_infarction.incidence_rate")
-            - RiskEffect("risk_factor.high_systolic_blood_pressure", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
-            - RiskEffect("risk_factor.high_systolic_blood_pressure", "cause.acute_ischemic_stroke.incidence_rate")
-            - RiskEffect("risk_factor.high_systolic_blood_pressure", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
-            - RiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
-            - RiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_residual.incidence_rate")
-
-            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.acute_myocardial_infarction.incidence_rate")
-            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
-            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.acute_ischemic_stroke.incidence_rate")
-            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
-            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
-            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_residual.incidence_rate")
-
-            - RiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.acute_myocardial_infarction.incidence_rate")
-            - RiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
-            - RiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.acute_ischemic_stroke.incidence_rate")
-            - RiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
-
     vivarium_nih_us_cvd:
         components:
-            - ResultsStratifier()
+            - Causes()
 
-            - IschemicStroke()
-            - IschemicHeartDiseaseAndHeartFailure()
+            - ResultsStratifier()
 
             - AdjustedRisk("risk_factor.high_ldl_cholesterol")
             - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
@@ -73,6 +31,48 @@ components:
             - LinearScaleUp("risk_factor.lifestyle")
             - CategoricalColumnObserver("outreach")
             - CategoricalColumnObserver("polypill")
+            - LifestyleObserver()
+
+    vivarium_public_health:
+        population:
+            - BasePopulation()
+            - Mortality()
+        metrics:
+            - MortalityObserver()
+            - DisabilityObserver()
+            - DiseaseObserver("ischemic_stroke")
+            - DiseaseObserver("ischemic_heart_disease_and_heart_failure")
+        risks:
+            - Risk("risk_factor.sbp_medication_adherence")
+            - Risk("risk_factor.ldlc_medication_adherence")
+            # these exposures are the percentage of eligible simulants who get enrolled
+            - Risk("risk_factor.outreach")
+            - Risk("risk_factor.polypill")
+            - Risk("risk_factor.lifestyle")
+
+            - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
+            - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
+            - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_ischemic_stroke.incidence_rate")
+            - RiskEffect("risk_factor.high_ldl_cholesterol", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
+
+            - RiskEffect("risk_factor.high_systolic_blood_pressure", "cause.acute_myocardial_infarction.incidence_rate")
+            - RiskEffect("risk_factor.high_systolic_blood_pressure", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
+            - RiskEffect("risk_factor.high_systolic_blood_pressure", "cause.acute_ischemic_stroke.incidence_rate")
+            - RiskEffect("risk_factor.high_systolic_blood_pressure", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
+            - RiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
+            - RiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_residual.incidence_rate")
+
+            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.acute_myocardial_infarction.incidence_rate")
+            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
+            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.acute_ischemic_stroke.incidence_rate")
+            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
+            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
+            - RiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_residual.incidence_rate")
+
+            - RiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.acute_myocardial_infarction.incidence_rate")
+            - RiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
+            - RiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.acute_ischemic_stroke.incidence_rate")
+            - RiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
 
 configuration:
     input_data:
@@ -91,25 +91,21 @@ configuration:
             year: 2021 # Includes two years for burn-in
             month: 1
             day: 1
-        observation_start: # TODO: Implement for all observers (currently only custom observers)
-            year: 2023
-            month: 1
-            day: 1
         end:
-            year: 2040
-            month: 12
-            day: 31
+            year: 2021
+            month: 1
+            day: 28
         step_size: 28 # Days
     population:
         population_size: 50_000
         age_start: 5
         age_end: 125
         exit_age: 125
-    observers:
+    stratification:
         default:
-            - 'age'
+            - 'age_group'
             - 'sex'
-            - 'year'
+            - 'current_year'
         sbp_medication:
             include:
                 - 'sbp_medication_adherence'

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -91,9 +91,9 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2021
-            month: 1
-            day: 28
+            year: 2040
+            month: 12
+            day: 31
         step_size: 28 # Days
     population:
         population_size: 50_000


### PR DESCRIPTION
## Refactor custom CVD observers

### Description
- *Category*: refactor
- *JIRA issue*: [MIC-4094](https://jira.ihme.washington.edu/browse/MIC-4094)

### Changes and notes
Refactor custom CVD observers to use new results management system in VPH. Add new lifestyle intervention observer. Remove custom observation start time. Reorder VPH and repo components so VPH observers comes after causes (we have to do this because of a property of the mortality observer).

### Verification and Testing
Ran simulation for one step and checked that we were seeing expected outputs. Added sbp medication adherence stratification to check results stratifier changes. Checked in interactive sim that values were what we expected for each observer. 