### PR TITLE
binned exposure observer

### DIFF
--- a/src/vivarium_nih_us_cvd/components/__init__.py
+++ b/src/vivarium_nih_us_cvd/components/__init__.py
@@ -3,6 +3,7 @@ from .effects import InterventionAdherenceEffect
 from .healthcare_utilization import HealthcareUtilization
 from .interventions import LinearScaleUp
 from .observers import (
+    BinnedRiskObserver,
     CategoricalColumnObserver,
     ContinuousRiskObserver,
     HealthcareVisitObserver,

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -367,11 +367,15 @@ class BinnedRiskObserver:
 
         for left_threshold_idx in range(0, len(thresholds) - 1):
             builder.results.register_observation(
-                name=(f"total_exposure_time_risk_{self.risk.name}"
-                     f"_between_{thresholds[left_threshold_idx]}_and_{thresholds[left_threshold_idx+1]}"),
-                pop_filter=(f'alive == "alive" and '
-                            f'`{self.risk.name}.exposure` >= {thresholds[left_threshold_idx]} '
-                            f'and `{self.risk.name}.exposure` < {thresholds[left_threshold_idx+1]}'),
+                name=(
+                    f"total_exposure_time_risk_{self.risk.name}"
+                    f"_between_{thresholds[left_threshold_idx]}_and_{thresholds[left_threshold_idx+1]}"
+                ),
+                pop_filter=(
+                    f'alive == "alive" and '
+                    f"`{self.risk.name}.exposure` >= {thresholds[left_threshold_idx]} "
+                    f"and `{self.risk.name}.exposure` < {thresholds[left_threshold_idx+1]}"
+                ),
                 aggregator=self.aggregate_state_person_time,
                 requires_columns=["alive"],
                 requires_values=[f"{self.risk.name}.exposure"],

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -344,11 +344,9 @@ class BinnedRiskObserver:
         columns_required = ["alive"]
         self.population_view = builder.population.get_view(columns_required)
 
-        if self.risk.name == "high_ldl_cholesterol":
-            thresholds = data_values.BINNED_OBSERVER_THRESHOLDS.LDL_THRESHOLDS
-        elif self.risk.name == "high_systolic_blood_pressure":
-            thresholds = data_values.BINNED_OBSERVER_THRESHOLDS.SBP_THRESHOLDS
-        else:
+        try:
+            thresholds = data_values.BINNED_OBSERVER_THRESHOLDS[self.risk.name]
+        except:
             raise ValueError(
                 "Thresholds only defined for high_ldl_cholesterol and high_systolic_blood_pressure."
                 f"You provided {self.risk}."

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -290,3 +290,106 @@ class LifestyleObserver(CategoricalColumnObserver):
 
     def calculate_unexposed_lifestyle_person_time(self, x: pd.DataFrame) -> float:
         return sum(x["lifestyle"].isna()) * to_years(self.step_size())
+
+
+class BinnedRiskObserver:
+    """Observes (continuous) risk exposure-time per group binned by exposure thresholds."""
+
+    configuration_defaults = {
+        "stratification": {
+            "risk": {
+                "exclude": [],
+                "include": [],
+            }
+        }
+    }
+
+    def __init__(self, risk: str):
+        self.risk = EntityString(risk)
+        self.configuration_defaults = self._get_configuration_defaults()
+
+    def __repr__(self):
+        return f"BinnedRiskObserver({self.risk})"
+
+    ##########################
+    # Initialization methods #
+    ##########################
+
+    # noinspection PyMethodMayBeStatic
+    def _get_configuration_defaults(self) -> Dict[str, Dict]:
+        return {
+            "stratification": {
+                f"binned_{self.risk}": ContinuousRiskObserver.configuration_defaults[
+                    "stratification"
+                ]["risk"]
+            }
+        }
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return f"binned_risk_observer.{self.risk}"
+
+    #################
+    # Setup methods #
+    #################
+
+    def setup(self, builder: Builder) -> None:
+        self.step_size = builder.time.step_size()
+        self.config = builder.configuration.stratification[f"binned_{self.risk}"]
+
+        columns_required = ["alive"]
+        self.population_view = builder.population.get_view(columns_required)
+
+        if self.risk.name == "high_ldl_cholesterol":
+            thresholds = data_values.BINNED_OBSERVER_THRESHOLDS.LDL_THRESHOLDS
+        elif self.risk.name == "high_systolic_blood_pressure":
+            thresholds = data_values.BINNED_OBSERVER_THRESHOLDS.SBP_THRESHOLDS
+        else:
+            raise ValueError(
+                "Thresholds only defined for high_ldl_cholesterol and high_systolic_blood_pressure."
+                f"You provided {self.risk}."
+            )
+
+        builder.results.register_observation(
+            name=f"total_exposure_time_risk_{self.risk.name}_below_{thresholds[0]}",
+            pop_filter=f'alive == "alive" and `{self.risk.name}.exposure` < {thresholds[0]}',
+            aggregator=self.aggregate_state_person_time,
+            requires_columns=["alive"],
+            requires_values=[f"{self.risk.name}.exposure"],
+            additional_stratifications=self.config.include,
+            excluded_stratifications=self.config.exclude,
+            when="collect_metrics",
+        )
+
+        for left_threshold_idx in range(0, len(thresholds) - 1):
+            builder.results.register_observation(
+                name=(f"total_exposure_time_risk_{self.risk.name}"
+                     f"_between_{thresholds[left_threshold_idx]}_and_{thresholds[left_threshold_idx+1]}"),
+                pop_filter=(f'alive == "alive" and '
+                            f'`{self.risk.name}.exposure` >= {thresholds[left_threshold_idx]} '
+                            f'and `{self.risk.name}.exposure` < {thresholds[left_threshold_idx+1]}'),
+                aggregator=self.aggregate_state_person_time,
+                requires_columns=["alive"],
+                requires_values=[f"{self.risk.name}.exposure"],
+                additional_stratifications=self.config.include,
+                excluded_stratifications=self.config.exclude,
+                when="collect_metrics",
+            )
+
+        builder.results.register_observation(
+            name=f"total_exposure_time_risk_{self.risk.name}_above_{thresholds[len(thresholds)-1]}",
+            pop_filter=f'alive == "alive" and `{self.risk.name}.exposure` >= {thresholds[len(thresholds)-1]}',
+            aggregator=self.aggregate_state_person_time,
+            requires_columns=["alive"],
+            requires_values=[f"{self.risk.name}.exposure"],
+            additional_stratifications=self.config.include,
+            excluded_stratifications=self.config.exclude,
+            when="collect_metrics",
+        )
+
+    def aggregate_state_person_time(self, x: pd.DataFrame) -> float:
+        return len(x) * to_years(self.step_size())

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -634,6 +634,23 @@ POLYPILL_SBP_MEDICATION_ADHERENCE_COVERAGE = {
 }
 
 
+#######################
+# Observer Parameters #
+#######################
+
+class __BinnedObserverThresholds(NamedTuple):
+    """categorical sbp exposure thresholds"""
+
+    LDL_THRESHOLDS: list = [2.59, 3.36, 4.14, 4.91]
+    SBP_THRESHOLDS: list = [130, 140]
+
+    @property
+    def name(self):
+        return "binned_observer_thresholds"
+
+BINNED_OBSERVER_THRESHOLDS = __BinnedObserverThresholds()
+
+
 # Modelable entity IDs
 ACUTE_MI_ME_ID = 24694
 POST_MI_ME_ID = 15755

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -639,8 +639,8 @@ POLYPILL_SBP_MEDICATION_ADHERENCE_COVERAGE = {
 #######################
 
 BINNED_OBSERVER_THRESHOLDS = {
-    'high_ldl_cholesterol': [2.59, 3.36, 4.14, 4.91],
-    'high_systolic_blood_pressure': [130, 140]
+    "high_ldl_cholesterol": [2.59, 3.36, 4.14, 4.91],
+    "high_systolic_blood_pressure": [130, 140],
 }
 
 

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -638,6 +638,7 @@ POLYPILL_SBP_MEDICATION_ADHERENCE_COVERAGE = {
 # Observer Parameters #
 #######################
 
+
 class __BinnedObserverThresholds(NamedTuple):
     """categorical sbp exposure thresholds"""
 
@@ -647,6 +648,7 @@ class __BinnedObserverThresholds(NamedTuple):
     @property
     def name(self):
         return "binned_observer_thresholds"
+
 
 BINNED_OBSERVER_THRESHOLDS = __BinnedObserverThresholds()
 

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -638,19 +638,10 @@ POLYPILL_SBP_MEDICATION_ADHERENCE_COVERAGE = {
 # Observer Parameters #
 #######################
 
-
-class __BinnedObserverThresholds(NamedTuple):
-    """categorical sbp exposure thresholds"""
-
-    LDL_THRESHOLDS: list = [2.59, 3.36, 4.14, 4.91]
-    SBP_THRESHOLDS: list = [130, 140]
-
-    @property
-    def name(self):
-        return "binned_observer_thresholds"
-
-
-BINNED_OBSERVER_THRESHOLDS = __BinnedObserverThresholds()
+BINNED_OBSERVER_THRESHOLDS = {
+    'high_ldl_cholesterol': [2.59, 3.36, 4.14, 4.91],
+    'high_systolic_blood_pressure': [130, 140]
+}
 
 
 # Modelable entity IDs

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -7,9 +7,11 @@ components:
 
             - AdjustedRisk("risk_factor.high_ldl_cholesterol")
             - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
-            
+            - BinnedRiskObserver("risk_factor.high_ldl_cholesterol")
+
             - AdjustedRisk("risk_factor.high_systolic_blood_pressure")
             - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
+            - BinnedRiskObserver("risk_factor.high_systolic_blood_pressure")
 
             - TruncatedRisk("risk_factor.high_body_mass_index_in_adults")
             - ContinuousRiskObserver("risk_factor.high_body_mass_index_in_adults")
@@ -21,7 +23,7 @@ components:
 
             - HealthcareUtilization()  # NOTE: this uses Treatment() as a sub-component
             - HealthcareVisitObserver()
-        
+
             - CategoricalColumnObserver("sbp_medication")
             - CategoricalColumnObserver("ldlc_medication")
 


### PR DESCRIPTION
## binned exposure observer

### Description
- *Category*: observer
- *JIRA issue*: [MIC-3558](https://jira.ihme.washington.edu/browse/MIC-3558)
- *Research reference*: [population achieving target values in model output tables](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_us_cvd/concept_model.html#model-outputs)

### Changes and notes
Add observer to calculate person time for risk exposures in binned exposure categories. 

### Verification and Testing
Ran simulation for one step and checked that we got expected outputs. Checked interactively that the values we saw were what we expect by looking at the metrics pipeline values  and calculating person time manually. 