### PR TITLE
Second LDL ramp update

### DIFF
--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -773,12 +773,12 @@ class Treatment:
         high_ascvd = ascvd[ascvd >= data_values.ASCVD_THRESHOLD.HIGH].index
         low_ldlc = measured_ldlc[measured_ldlc < data_values.LDLC_THRESHOLD.LOW].index
         above_medium_ldlc_male = measured_ldlc[
-            (pop_visitors['sex'] == 'Male') &
-            (measured_ldlc >= data_values.LDLC_THRESHOLD.MEDIUM_MALE)
+            (pop_visitors["sex"] == "Male")
+            & (measured_ldlc >= data_values.LDLC_THRESHOLD.MEDIUM_MALE)
         ].index
         above_medium_ldlc_female = measured_ldlc[
-            (pop_visitors['sex'] == 'Female') &
-            (measured_ldlc >= data_values.LDLC_THRESHOLD.MEDIUM_FEMALE)
+            (pop_visitors["sex"] == "Female")
+            & (measured_ldlc >= data_values.LDLC_THRESHOLD.MEDIUM_FEMALE)
         ].index
         above_medium_ldlc = above_medium_ldlc_male.append(above_medium_ldlc_female)
         high_ldlc = measured_ldlc[measured_ldlc >= data_values.LDLC_THRESHOLD.HIGH].index

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -772,9 +772,15 @@ class Treatment:
         low_ascvd = ascvd[ascvd < data_values.ASCVD_THRESHOLD.LOW].index
         high_ascvd = ascvd[ascvd >= data_values.ASCVD_THRESHOLD.HIGH].index
         low_ldlc = measured_ldlc[measured_ldlc < data_values.LDLC_THRESHOLD.LOW].index
-        above_medium_ldlc = measured_ldlc[
-            measured_ldlc >= data_values.LDLC_THRESHOLD.MEDIUM
+        above_medium_ldlc_male = measured_ldlc[
+            (pop_visitors['sex'] == 'Male') &
+            (measured_ldlc >= data_values.LDLC_THRESHOLD.MEDIUM_MALE)
         ].index
+        above_medium_ldlc_female = measured_ldlc[
+            (pop_visitors['sex'] == 'Female') &
+            (measured_ldlc >= data_values.LDLC_THRESHOLD.MEDIUM_FEMALE)
+        ].index
+        above_medium_ldlc = above_medium_ldlc_male.append(above_medium_ldlc_female)
         high_ldlc = measured_ldlc[measured_ldlc >= data_values.LDLC_THRESHOLD.HIGH].index
         mask_history_mi = (
             pop_visitors[models.ISCHEMIC_HEART_DISEASE_AND_HEART_FAILURE_MODEL_NAME]

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -181,7 +181,8 @@ class __LDLCThreshold(NamedTuple):
     """ldl-c exposure thresholds"""
 
     LOW: float = 1.81
-    MEDIUM: float = 2.91
+    MEDIUM_MALE: float = 3.08
+    MEDIUM_FEMALE: float = 3.48
     HIGH: float = 4.91
 
     @property

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -98,7 +98,7 @@ configuration:
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 100_000
+        population_size: 50_000
         age_start: 5
         age_end: 125
         exit_age: 125

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -99,7 +99,7 @@ configuration:
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 1_000
+        population_size: 100_000
         age_start: 5
         age_end: 125
         exit_age: 125

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -79,8 +79,7 @@ configuration:
     input_data:
         input_draw_number: 0
         location: 'Alabama'
-        #artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
-        artifact_path: '/home/hussain-jafari/artifacts/alabama.hdf'
+        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -79,7 +79,8 @@ configuration:
     input_data:
         input_draw_number: 0
         location: 'Alabama'
-        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
+        #artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
+        artifact_path: '/home/hussain-jafari/artifacts/alabama.hdf'
     interpolation:
         order: 0
         extrapolate: True
@@ -98,7 +99,7 @@ configuration:
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 50_000
+        population_size: 1_000
         age_start: 5
         age_end: 125
         exit_age: 125


### PR DESCRIPTION
## Second LDL ramp update

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-4158](https://jira.ihme.washington.edu/browse/MIC-4158)
- *Research reference*: [LDL-C Treatment Ramp](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_us_cvd/concept_model.html#healthcare-system-modeling)

### Changes and notes
Second update of LDL ramp to have sex-specific and higher thresholds for 75+ simulants to be assigned LDL medication.

### Verification and Testing
Used a breakpoint and checked that people were being placed in the right sets given their age, medication history, and measured LDL.