### PR TITLE
Aging past exit year stratification bugfix

### DIFF
--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -31,7 +31,7 @@ class ResultsStratifier(ResultsStratifier_):
         age_bins = super().get_age_bins(builder)
         age_bins = age_bins[age_bins["age_start"] >= 25.0].reset_index(drop=True)
         age_bins.loc[len(age_bins.index)] = [5.0, 25.0, "5_to_24"]
-        
+
         # FIXME: MIC-4083 simulants can age past 125
         max_age = age_bins["age_end"].max()
         age_bins.loc[age_bins["age_end"] == max_age, "age_end"] += (

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -31,6 +31,12 @@ class ResultsStratifier(ResultsStratifier_):
         age_bins = super().get_age_bins(builder)
         age_bins = age_bins[age_bins["age_start"] >= 25.0].reset_index(drop=True)
         age_bins.loc[len(age_bins.index)] = [5.0, 25.0, "5_to_24"]
+        
+        # FIXME: MIC-4083 simulants can age past 125
+        max_age = age_bins["age_end"].max()
+        age_bins.loc[age_bins["age_end"] == max_age, "age_end"] += (
+            builder.configuration.time.step_size / 365.25
+        )
 
         return age_bins.sort_values(["age_start"]).reset_index(drop=True)
 


### PR DESCRIPTION
## Aging past exit year stratification bugfix

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4205](https://jira.ihme.washington.edu/browse/MIC-4205)

### Changes and notes
Increase the maximum age bin age end by one step size to account for simulants who have aged past the exit year. 

### Verification and Testing
Made it past time steps in a simulation which was previously failing because of this error. 