### PR TITLE
only pull tracked pop in treatment when appropriate

### DIFF
--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -585,7 +585,7 @@ class Treatment:
 
     def on_time_step_cleanup(self, event: Event) -> None:
         """Update treatments"""
-        pop = self.population_view.get(event.index, query='alive == "alive"')
+        pop = self.population_view.get(event.index, query='alive == "alive" & tracked==True')
 
         visitors = pop[
             pop[data_values.COLUMNS.VISIT_TYPE].isin(


### PR DESCRIPTION
## only pull tracked pop in treatment when appropriate

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4241](https://jira.ihme.washington.edu/browse/MIC-4241)

### Changes and notes
Pulling tracked would lead to nans in state table.

### Verification and Testing
Sim is running where it previously failed.