### PR TITLE
change therapeutic inertia for simulants changing SBP medication

### DIFF
--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -719,7 +719,9 @@ class Treatment:
             pop_visitors[data_values.COLUMNS.SBP_MEDICATION]
             != self.sbp_treatment_map[max(self.sbp_treatment_map)]
         ].index
-        changing_prescribed_medication = to_prescribe_d.intersection(adherent).intersection(not_already_max_medicated)
+        changing_prescribed_medication = to_prescribe_d.intersection(adherent).intersection(
+            not_already_max_medicated
+        )
         medication_change = to_prescribe_b.union(changing_prescribed_medication)
         pop_visitors.loc[medication_change, data_values.COLUMNS.SBP_MEDICATION] = (
             pop_visitors[data_values.COLUMNS.SBP_MEDICATION].map(
@@ -728,10 +730,12 @@ class Treatment:
             + 1
         ).map(self.sbp_treatment_map)
         # update therapeutic inertia for people on medication going up a level
-        self.dynamic_therapeutic_inertia_propensity.loc[changing_prescribed_medication] = self.randomness.get_draw(
-                changing_prescribed_medication,
-                additional_key="dynamic_therapeutic_inertia_" + str(self.clock()),
-            )
+        self.dynamic_therapeutic_inertia_propensity.loc[
+            changing_prescribed_medication
+        ] = self.randomness.get_draw(
+            changing_prescribed_medication,
+            additional_key="dynamic_therapeutic_inertia_" + str(self.clock()),
+        )
 
         # Determine potential new outreach enrollees; applies to groups b, c, and
         # everyone already on medication

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -369,7 +369,9 @@ class Treatment:
         ).get(pop_data.index)
 
         # Define propensities for therapeutic inertia
-        pop[data_values.COLUMNS.SBP_THERAPEUTIC_INERTIA_PROPENSITY] = self.randomness.get_draw(
+        pop[
+            data_values.COLUMNS.SBP_THERAPEUTIC_INERTIA_PROPENSITY
+        ] = self.randomness.get_draw(
             pop.index, additional_key=data_values.COLUMNS.SBP_THERAPEUTIC_INERTIA_PROPENSITY
         )
 
@@ -648,7 +650,9 @@ class Treatment:
         if not exposure_pipeline:
             exposure_pipeline = self.sbp
 
-        sbp_prescription_inertia_propensity = pop_visitors[data_values.COLUMNS.SBP_THERAPEUTIC_INERTIA_PROPENSITY]
+        sbp_prescription_inertia_propensity = pop_visitors[
+            data_values.COLUMNS.SBP_THERAPEUTIC_INERTIA_PROPENSITY
+        ]
         # Uses old propensity to determine who changed medication the previous time step
         overcome_prescription_inertia = pop_visitors[
             sbp_prescription_inertia_propensity > data_values.SBP_THERAPEUTIC_INERTIA
@@ -660,10 +664,13 @@ class Treatment:
 
         # Update inertia values for those who moved up a medication level on the previous time step
         # and use to update medications
-        changed_prescription_last_time = overcome_prescription_inertia.intersection(currently_medicated)
-        sbp_prescription_inertia_propensity.loc[changed_prescription_last_time] = self.randomness.get_draw(
-            changed_prescription_last_time,
-            additional_key="dynamic_inertia_propensity"
+        changed_prescription_last_time = overcome_prescription_inertia.intersection(
+            currently_medicated
+        )
+        sbp_prescription_inertia_propensity.loc[
+            changed_prescription_last_time
+        ] = self.randomness.get_draw(
+            changed_prescription_last_time, additional_key="dynamic_inertia_propensity"
         )
         overcome_prescription_inertia = pop_visitors[
             sbp_prescription_inertia_propensity > data_values.SBP_THERAPEUTIC_INERTIA
@@ -725,8 +732,10 @@ class Treatment:
             pop_visitors[data_values.COLUMNS.SBP_MEDICATION]
             != self.sbp_treatment_map[max(self.sbp_treatment_map)]
         ].index
-        medication_change = to_prescribe_b.union(to_prescribe_d).intersection(adherent).intersection(
-            not_already_max_medicated
+        medication_change = (
+            to_prescribe_b.union(to_prescribe_d)
+            .intersection(adherent)
+            .intersection(not_already_max_medicated)
         )
         pop_visitors.loc[medication_change, data_values.COLUMNS.SBP_MEDICATION] = (
             pop_visitors[data_values.COLUMNS.SBP_MEDICATION].map(

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -707,7 +707,9 @@ class Treatment:
         to_prescribe_b = newly_prescribed.difference(to_prescribe_c)
         # [Treatment ramp ID D] Simulants who overcome therapeutic inertia, have
         # high sbp, and are currently medicated
-        to_prescribe_d = medicated_high_sbp.intersection(updated_overcome_prescription_inertia)
+        to_prescribe_d = medicated_high_sbp.intersection(
+            updated_overcome_prescription_inertia
+        )
 
         # Prescribe initial medications
         pop_visitors.loc[

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -672,8 +672,8 @@ class Treatment:
         high_sbp = measured_sbp[measured_sbp >= data_values.SBP_THRESHOLD.HIGH].index
         medicated_high_sbp = currently_medicated.intersection(high_sbp)
 
-        # Update inertia values for those who moved up a medication level on the previous time step
-        # and use to update medications
+        # Update inertia values for those who moved up a medication level
+        # last time they had a high SBP measured during a doctor visit
         changed_prescription_last_time = overcome_prescription_inertia.intersection(
             medicated_high_sbp
         )

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -25,6 +25,7 @@ class __Columns(NamedTuple):
     POLYPILL: str = "polypill"
     LIFESTYLE: str = "lifestyle"
     LAST_FPG_TEST_DATE: str = "last_fpg_test_date"
+    SBP_THERAPEUTIC_INERTIA_PROPENSITY: str = "sbp_therapeutic_inertia_propensity"
 
     @property
     def name(self):


### PR DESCRIPTION
## change therapeutic inertia for simulants changing SBP medication

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-4263](https://jira.ihme.washington.edu/browse/MIC-4263)
- *Research reference*: [SBP Treatment Ramp](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_us_cvd/concept_model.html#healthcare-system-modeling)

### Changes and notes
Keep therapeutic inertia constant for simulants initially being prescribed medication and update inertia once a simulant goes up a level in their prescribed medication.

### Verification and Testing
Checked interactively that simulants who go up a level were given a new inertia propensity the next step and that simulants whose medication didn't change had the same propensity. 