### PR TITLE
Update SBP inertia state table properly

### DIFF
--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -681,7 +681,7 @@ class Treatment:
         sbp_prescription_inertia_propensity.loc[
             changed_prescription_last_time
         ] = self.randomness.get_draw(
-            changed_prescription_last_time, additional_key="dynamic_inertia_propensity"
+            changed_prescription_last_time, additional_key="dynamic_sbp_inertia_propensity"
         )
         updated_overcome_prescription_inertia = pop_visitors[
             sbp_prescription_inertia_propensity > data_values.SBP_THERAPEUTIC_INERTIA

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -631,6 +631,7 @@ class Treatment:
                 [
                     data_values.COLUMNS.SBP_MEDICATION,
                     data_values.COLUMNS.LDLC_MEDICATION,
+                    data_values.COLUMNS.SBP_THERAPEUTIC_INERTIA_PROPENSITY,
                 ]
             ]
         )

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -764,7 +764,9 @@ class Treatment:
             )
 
         # Update propensity in visitors
-        pop_visitors[data_values.COLUMNS.SBP_THERAPEUTIC_INERTIA_PROPENSITY] = sbp_prescription_inertia_propensity
+        pop_visitors[
+            data_values.COLUMNS.SBP_THERAPEUTIC_INERTIA_PROPENSITY
+        ] = sbp_prescription_inertia_propensity
 
         return pop_visitors, maybe_enroll
 

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -763,8 +763,8 @@ class Treatment:
                 high_sbp.union(history_mi_or_is.difference(low_sbp))
             )
 
-        # Update state table to have new propensities
-        self.population_view.update(sbp_prescription_inertia_propensity)
+        # Update propensity in visitors
+        pop_visitors[data_values.COLUMNS.SBP_THERAPEUTIC_INERTIA_PROPENSITY] = sbp_prescription_inertia_propensity
 
         return pop_visitors, maybe_enroll
 


### PR DESCRIPTION
## Update SBP inertia state table properly

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4263](https://jira.ihme.washington.edu/browse/MIC-4263)
- *Research reference*: [SBP Treatment Ramp](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_us_cvd/concept_model.html#healthcare-system-modeling)

### Changes and notes
Update entire state table at initialization by passing updated information about visitors. 

### Verification and Testing
Ran simulation for a few time steps. 