### PR TITLE
Feature/sbachmei/mic 4579 joint pafs artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ dmypy.json
 
 # Pycharm project settings
 .idea/
+
+# vscode
+.vscode/

--- a/paf_utilities/README.md
+++ b/paf_utilities/README.md
@@ -60,7 +60,7 @@ STEP 4: ADD PAFS TO THE ARTIFACTS
     ```
     >>> make_artifacts --pdb -vvval all -o /mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/51-locations/<VERSION>
     ```
-2. Confirm that all artifacts have 5 PAF keys
+2. Confirm that all artifacts have the joint PAF key
     ```
     python3 check_artifact_pafs.py -d <ROOT-DIR> -v <VERSION>
     ```

--- a/paf_utilities/README.md
+++ b/paf_utilities/README.md
@@ -58,7 +58,7 @@ STEP 4: ADD PAFS TO THE ARTIFACTS
 ---------------------------------
 1. Append the new PAF data to the artifacts
     ```
-    >>> make_artifacts --pdb -vvval all -o /mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/51-locations/<VERSION>
+    >>> make_artifacts --pdb -vvv -a -o /mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/51-locations/<VERSION>
     ```
 2. Confirm that all artifacts have 5 PAF keys
     ```

--- a/paf_utilities/README.md
+++ b/paf_utilities/README.md
@@ -58,7 +58,7 @@ STEP 4: ADD PAFS TO THE ARTIFACTS
 ---------------------------------
 1. Append the new PAF data to the artifacts
     ```
-    >>> make_artifacts --pdb -vvv -a -o /mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/51-locations/<VERSION>
+    >>> make_artifacts --pdb -vvval all -o /mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/51-locations/<VERSION>
     ```
 2. Confirm that all artifacts have 5 PAF keys
     ```

--- a/paf_utilities/check_artifact_pafs.py
+++ b/paf_utilities/check_artifact_pafs.py
@@ -15,7 +15,13 @@ def main(root_dir: Path) -> None:
         filename = file.name
         print(f"Checking {filename}")
         art = Artifact(file)
-        num_paf_keys = len([k for k in art.keys if "joint.population_attributable_fraction" in k])
+        num_paf_keys = len(
+            [
+                k
+                for k in art.keys
+                if "joint_mediated_risks.population_attributable_fraction" in k
+            ]
+        )
         if num_paf_keys != EXPECTED_NUM_PAF_KEYS:
             print(f"\nMISSING! - {filename}: {num_paf_keys} PAF keys\n")
             bad_files.append(filename)

--- a/paf_utilities/check_artifact_pafs.py
+++ b/paf_utilities/check_artifact_pafs.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from vivarium import Artifact
 
-EXPECTED_NUM_PAF_KEYS = 5
+EXPECTED_NUM_PAF_KEYS = 1
 
 
 def main(root_dir: Path) -> None:
@@ -15,7 +15,7 @@ def main(root_dir: Path) -> None:
         filename = file.name
         print(f"Checking {filename}")
         art = Artifact(file)
-        num_paf_keys = len([k for k in art.keys if "population_attributable_fraction" in k])
+        num_paf_keys = len([k for k in art.keys if "joint.population_attributable_fraction" in k])
         if num_paf_keys != EXPECTED_NUM_PAF_KEYS:
             print(f"\nMISSING! - {filename}: {num_paf_keys} PAF keys\n")
             bad_files.append(filename)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 
     # use "pip install -e .[dev]" to install all components
     data_requirements = ["vivarium_inputs[data]==4.1.0"]
-    cluster_requirements = ["vivarium_cluster_tools>=1.3.9"]
+    cluster_requirements = ["vivarium_cluster_tools>=1.3.13"]
     test_requirements = ["pytest"]
 
     setup(

--- a/src/vivarium_nih_us_cvd/components/__init__.py
+++ b/src/vivarium_nih_us_cvd/components/__init__.py
@@ -11,8 +11,8 @@ from .observers import (
     CategoricalColumnObserver,
     ContinuousRiskObserver,
     HealthcareVisitObserver,
+    JointPAFObserver,
     LifestyleObserver,
-    PAFObserver,
     ResultsStratifier,
     SimpleResultsStratifier,
 )

--- a/src/vivarium_nih_us_cvd/components/effects.py
+++ b/src/vivarium_nih_us_cvd/components/effects.py
@@ -96,21 +96,6 @@ class InterventionAdherenceEffect(Component):
         return target
 
 
-class PAFCalculationRiskEffect(RiskEffect):
-    """Risk effect component for calculating PAFs"""
-
-    def get_population_attributable_fraction_source(
-        self, builder: Builder
-    ) -> Optional[LookupTable]:
-        return None
-
-    def register_target_modifier(self, builder: Builder) -> None:
-        pass
-
-    def register_paf_modifier(self, builder: Builder) -> None:
-        pass
-
-
 MEDIATOR_NAMES = {
     "high_body_mass_index_in_adults": {
         "acute_ischemic_stroke": [
@@ -253,3 +238,18 @@ class MediatedRiskEffect(RiskEffect):
             requires_values=[f"{self.risk.name}.exposure"],
             requires_columns=["age", "sex"],
         )
+
+
+class PAFCalculationRiskEffect(MediatedRiskEffect):
+    """Risk effect component for calculating PAFs"""
+
+    def get_population_attributable_fraction_source(
+        self, builder: Builder
+    ) -> Optional[LookupTable]:
+        return None
+
+    def register_target_modifier(self, builder: Builder) -> None:
+        pass
+
+    def register_paf_modifier(self, builder: Builder) -> None:
+        pass

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -415,6 +415,10 @@ class JointPAFObserver(Component):
         self.risks_and_mediators = self._get_risks_and_mediators()
 
     def _get_risks_and_mediators(self) -> Set[str]:
+        """ MEDIATOR_NAMES is a nested dict like {risk: {target: [mediators]}}.
+        For each target in MEDIATOR_NAMES (the second-level keys), extract the
+        risks (the outer keys) and the mediator names (the child node lists).
+        """
         risks = {
             risk
             for risk, mediator_dict in MEDIATOR_NAMES.items()

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -415,8 +415,8 @@ class JointPAFObserver(Component):
         self.risks_and_mediators = self._get_risks_and_mediators()
 
     def _get_risks_and_mediators(self) -> Set[str]:
-        """ MEDIATOR_NAMES is a nested dict like {risk: {target: [mediators]}}.
-        For each target in MEDIATOR_NAMES (the second-level keys), extract the
+        """MEDIATOR_NAMES is a nested dict like {risk: {target: [mediators]}}.
+        For this instance target (the second-level keys), extract the
         risks (the outer keys) and the mediator names (the child node lists).
         """
         risks = {
@@ -453,10 +453,7 @@ class JointPAFObserver(Component):
     def calculate_paf(self, x: pd.DataFrame) -> float:
         joint_rrs = pd.Series(1.0, index=x.index)
         for risk in self.risk_effects:
-            relative_risk = self.risk_effects[risk].mediated_target_modifier(
-                x.index, pd.Series(1.0, index=x.index)
-            )
-            joint_rrs *= relative_risk
+            joint_rrs = self.risk_effects[risk].mediated_target_modifier(x.index, joint_rrs)
         mean_rr = joint_rrs.mean()
         paf = (mean_rr - 1.0) / mean_rr
         return paf

--- a/src/vivarium_nih_us_cvd/components/observers.py
+++ b/src/vivarium_nih_us_cvd/components/observers.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 import pandas as pd
 from vivarium import Component
@@ -8,6 +8,7 @@ from vivarium_public_health.metrics.stratification import (
 )
 from vivarium_public_health.utilities import EntityString, TargetString, to_years
 
+from vivarium_nih_us_cvd.components.effects import MEDIATOR_NAMES
 from vivarium_nih_us_cvd.constants import data_values
 
 
@@ -388,7 +389,7 @@ class BinnedRiskObserver(Component):
         return len(x) * to_years(self.step_size())
 
 
-class PAFObserver(Component):
+class JointPAFObserver(Component):
     CONFIGURATION_DEFAULTS = {
         "stratification": {
             "paf": {
@@ -402,38 +403,56 @@ class PAFObserver(Component):
     def configuration_defaults(self) -> Dict[str, Dict]:
         return {
             "stratification": {
-                f"{self.risk.name}_paf_on_{self.target.name}": self.CONFIGURATION_DEFAULTS[
+                f"joint_paf_on_{self.target.name}": self.CONFIGURATION_DEFAULTS[
                     "stratification"
                 ]["paf"]
             }
         }
 
-    def __init__(self, risk: str, target: str):
+    def __init__(self, target: str):
         super().__init__()
-        self.risk = EntityString(risk)
         self.target = TargetString(target)
+        self.risks_and_mediators = self._get_risks_and_mediators()
 
-    # noinspection PyAttributeOutsideInit
-    def setup(self, builder: Builder) -> None:
-        self.risk_effect = builder.components.get_component(
-            f"paf_calculation_risk_effect.{self.risk}.{self.target}"
+    def _get_risks_and_mediators(self) -> Set[str]:
+        risks = {
+            risk
+            for risk, mediator_dict in MEDIATOR_NAMES.items()
+            if self.target.name in mediator_dict.keys()
+        }
+        mediator_lists = [MEDIATOR_NAMES[risk][self.target.name] for risk in risks]
+        return risks.union(
+            {mediator for mediators in mediator_lists for mediator in mediators}
         )
 
-        config = builder.configuration.stratification[f"{self.risk.name}_paf"]
-
+    def setup(self, builder: Builder) -> None:
+        self.risk_effects = {
+            risk: builder.components.get_component(
+                f"paf_calculation_risk_effect.risk_factor.{risk}.{self.target}"
+            )
+            for risk in self.risks_and_mediators
+        }
+        config = builder.configuration.stratification[f"joint_paf_on_{self.target.name}"]
         builder.results.register_observation(
-            name=f"calculated_paf_{self.risk}_on_{self.target}",
+            name=f"joint_paf_on_{self.target}",
             pop_filter='alive == "alive"',
             aggregator=self.calculate_paf,
             requires_columns=["alive"],
+            requires_values=[
+                f"unadjusted_rr_{x}_on_{self.target.name}" for x in self.risks_and_mediators
+            ],
             additional_stratifications=config.include,
             excluded_stratifications=config.exclude,
             when="time_step__prepare",
         )
 
     def calculate_paf(self, x: pd.DataFrame) -> float:
-        relative_risk = self.risk_effect.target_modifier(x.index, pd.Series(1, index=x.index))
-        mean_rr = relative_risk.mean()
-        paf = (mean_rr - 1) / mean_rr
-
+        joint_rrs = pd.Series(1.0, index=x.index)
+        for risk in self.risk_effects:
+            relative_risk = self.risk_effects[risk].mediated_target_modifier(
+                x.index, pd.Series(1.0, index=x.index)
+            )
+            joint_rrs *= relative_risk
+        mean_rr = joint_rrs.mean()
+        paf = (mean_rr - 1.0) / mean_rr
         return paf

--- a/src/vivarium_nih_us_cvd/components/population.py
+++ b/src/vivarium_nih_us_cvd/components/population.py
@@ -22,6 +22,7 @@ class EvenlyDistributedPopulation(BasePopulation):
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
         self.location = builder.data.load(data_keys.POPULATION.LOCATION)
+        self.time_step = builder.configuration.time.step_size
 
     ########################
     # Event-driven methods #
@@ -29,8 +30,9 @@ class EvenlyDistributedPopulation(BasePopulation):
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         age_start = pop_data.user_data.get("age_start", self.config.age_start)
-        age_end = pop_data.user_data.get("age_end", self.config.age_end)
-
+        age_end = (
+            pop_data.user_data.get("age_end", self.config.age_end) - self.time_step / 365.25
+        )
         population = pd.DataFrame(index=pop_data.index)
         population["entrance_time"] = pop_data.creation_time
         population["exit_time"] = pd.NaT

--- a/src/vivarium_nih_us_cvd/constants/data_keys.py
+++ b/src/vivarium_nih_us_cvd/constants/data_keys.py
@@ -364,7 +364,9 @@ MEDIATION = __Mediation()
 
 
 class __JointPAFs(NamedTuple):
-    PAFS: TargetString = TargetString("risk_factor.joint.population_attributable_fraction")
+    PAFS: TargetString = TargetString(
+        "risk_factor.joint_mediated_risks.population_attributable_fraction"
+    )
 
     @property
     def name(self):

--- a/src/vivarium_nih_us_cvd/constants/data_keys.py
+++ b/src/vivarium_nih_us_cvd/constants/data_keys.py
@@ -154,9 +154,6 @@ class __HighLDLCholesterol(NamedTuple):
     RELATIVE_RISK: TargetString = TargetString(
         "risk_factor.high_ldl_cholesterol.relative_risk"
     )
-    PAF: TargetString = TargetString(
-        "risk_factor.high_ldl_cholesterol.population_attributable_fraction"
-    )
     TMRED: TargetString = TargetString("risk_factor.high_ldl_cholesterol.tmred")
     RELATIVE_RISK_SCALAR: TargetString = TargetString(
         "risk_factor.high_ldl_cholesterol.relative_risk_scalar"
@@ -199,12 +196,6 @@ class __HighSBP(NamedTuple):
     CATEGORICAL_RELATIVE_RISK: TargetString = TargetString(
         "risk_factor.categorical_high_systolic_blood_pressure.relative_risk"
     )
-    PAF: TargetString = TargetString(
-        "risk_factor.high_systolic_blood_pressure.population_attributable_fraction"
-    )
-    CATEGORICAL_PAF: TargetString = TargetString(
-        "risk_factor.categorical_high_systolic_blood_pressure.population_attributable_fraction"
-    )
     TMRED: TargetString = TargetString("risk_factor.high_systolic_blood_pressure.tmred")
     RELATIVE_RISK_SCALAR: TargetString = TargetString(
         "risk_factor.high_systolic_blood_pressure.relative_risk_scalar"
@@ -238,9 +229,6 @@ class __HighBMI(NamedTuple):
     RELATIVE_RISK: TargetString = TargetString(
         "risk_factor.high_body_mass_index_in_adults.relative_risk"
     )
-    PAF: TargetString = TargetString(
-        "risk_factor.high_body_mass_index_in_adults.population_attributable_fraction"
-    )
     TMRED: TargetString = TargetString("risk_factor.high_body_mass_index_in_adults.tmred")
     RELATIVE_RISK_SCALAR: TargetString = TargetString(
         "risk_factor.high_body_mass_index_in_adults.relative_risk_scalar"
@@ -273,9 +261,6 @@ class __HighFPG(NamedTuple):
     )
     RELATIVE_RISK: TargetString = TargetString(
         "risk_factor.high_fasting_plasma_glucose.relative_risk"
-    )
-    PAF: TargetString = TargetString(
-        "risk_factor.high_fasting_plasma_glucose.population_attributable_fraction"
     )
     TMRED: TargetString = TargetString("risk_factor.high_fasting_plasma_glucose.tmred")
     RELATIVE_RISK_SCALAR: TargetString = TargetString(
@@ -378,6 +363,21 @@ class __Mediation(NamedTuple):
 MEDIATION = __Mediation()
 
 
+class __JointPAFs(NamedTuple):
+    PAFS: TargetString = TargetString("risk_factor.joint.population_attributable_fraction")
+
+    @property
+    def name(self):
+        return "joint_pafs"
+
+    @property
+    def log_name(self):
+        return self.name.replace("_", " ")
+
+
+JOINT_PAFS = __JointPAFs()
+
+
 ##################
 # Artifact Items #
 ##################
@@ -395,4 +395,5 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     OUTREACH,
     POLYPILL,
     MEDIATION,
+    JOINT_PAFS,
 ]

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -682,45 +682,22 @@ def modify_rr_affected_entity(data: pd.DataFrame, mod_map: Dict[str, List[str]])
 
 def match_rr_to_cause_name(data: Union[str, pd.DataFrame], source_key: EntityKey):
     # Need to make relative risk data match causes in the model
-    is_calculated_paf = (
-        (source_key == data_keys.LDL_C.PAF)
-        or (source_key == data_keys.SBP.PAF)
-        or (source_key == data_keys.BMI.PAF)
-    )
-    if is_calculated_paf:
-        map = {
-            # not explicitly including these will delete them from the data
-            "acute_myocardial_infarction": ["acute_myocardial_infarction"],
-            "post_myocardial_infarction_to_acute_myocardial_infarction": [
-                "post_myocardial_infarction_to_acute_myocardial_infarction"
-            ],
-            "acute_ischemic_stroke": ["acute_ischemic_stroke"],
-            "chronic_ischemic_stroke_to_acute_ischemic_stroke": [
-                "chronic_ischemic_stroke_to_acute_ischemic_stroke"
-            ],
-            "heart_failure": [
-                "heart_failure_from_ischemic_heart_disease",
-                "heart_failure_residual",
-            ],
-        }
-    else:
-        map = {
-            "ischemic_heart_disease": [
-                "acute_myocardial_infarction",
-                "post_myocardial_infarction_to_acute_myocardial_infarction",
-            ],
-            "ischemic_stroke": [
-                "acute_ischemic_stroke",
-                "chronic_ischemic_stroke_to_acute_ischemic_stroke",
-            ],
-            "heart_failure": [
-                "heart_failure_from_ischemic_heart_disease",
-                "heart_failure_residual",
-            ],
-        }
+    map = {
+        "ischemic_heart_disease": [
+            "acute_myocardial_infarction",
+            "post_myocardial_infarction_to_acute_myocardial_infarction",
+        ],
+        "ischemic_stroke": [
+            "acute_ischemic_stroke",
+            "chronic_ischemic_stroke_to_acute_ischemic_stroke",
+        ],
+        "heart_failure": [
+            "heart_failure_from_ischemic_heart_disease",
+            "heart_failure_residual",
+        ],
+    }
     if source_key.measure in [
         "relative_risk",
-        "population_attributable_fraction",
         "mediation_factors",
     ]:
         data = modify_rr_affected_entity(data, map)

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -119,7 +119,6 @@ def get_data(
         data_keys.LDL_C.EXPOSURE_SD: load_ldl_standard_deviation,
         data_keys.LDL_C.EXPOSURE_WEIGHTS: load_ldl_weights,
         data_keys.LDL_C.RELATIVE_RISK: load_standard_data,
-        data_keys.LDL_C.PAF: partial(load_paf_ldl, artifact_path),
         data_keys.LDL_C.TMRED: load_metadata,
         data_keys.LDL_C.RELATIVE_RISK_SCALAR: load_metadata,
         data_keys.LDL_C.MEDICATION_EFFECT: load_ldlc_medication_effect,
@@ -131,8 +130,6 @@ def get_data(
         data_keys.SBP.EXPOSURE_WEIGHTS: load_sbp_weights,
         data_keys.SBP.RELATIVE_RISK: load_standard_data,
         data_keys.SBP.CATEGORICAL_RELATIVE_RISK: load_relative_risk_categorical_sbp,
-        data_keys.SBP.PAF: partial(load_paf_sbp, artifact_path),
-        data_keys.SBP.CATEGORICAL_PAF: partial(load_paf_categorical_sbp, artifact_path),
         data_keys.SBP.TMRED: load_metadata,
         data_keys.SBP.RELATIVE_RISK_SCALAR: load_metadata,
         # Risk (body mass index)
@@ -141,7 +138,6 @@ def get_data(
         data_keys.BMI.EXPOSURE_SD: load_bmi_standard_deviation,
         data_keys.BMI.EXPOSURE_WEIGHTS: load_bmi_weights,
         data_keys.BMI.RELATIVE_RISK: load_relative_risk_bmi,
-        data_keys.BMI.PAF: partial(load_paf_bmi, artifact_path),
         data_keys.BMI.TMRED: load_metadata,
         data_keys.BMI.RELATIVE_RISK_SCALAR: load_metadata,
         # Risk (fasting plasma glucose)
@@ -150,7 +146,6 @@ def get_data(
         data_keys.FPG.EXPOSURE_SD: load_fpg_standard_deviation,
         data_keys.FPG.EXPOSURE_WEIGHTS: load_standard_data,
         data_keys.FPG.RELATIVE_RISK: load_standard_data,
-        data_keys.FPG.PAF: load_standard_data,
         data_keys.FPG.TMRED: load_metadata,
         data_keys.FPG.RELATIVE_RISK_SCALAR: load_metadata,
         # Risk (ldlc medication adherence)
@@ -166,6 +161,8 @@ def get_data(
         # Mediation
         data_keys.MEDIATION.MEDIATION_FACTORS: load_mediation_factors,
         data_keys.MEDIATION.HF_DELTAS: load_hf_deltas,
+        # PAFs
+        data_keys.JOINT_PAFS.PAFS: partial(load_joint_pafs, artifact_path),
     }
     source_key = _get_source_key(lookup_key)
     data = mapping[lookup_key](source_key, location)
@@ -828,16 +825,6 @@ def load_relative_risk_categorical_sbp(key: str, location: str) -> pd.DataFrame:
     return heart_failure_rrs
 
 
-def load_paf_sbp(artifact_path: str, key: str, location: str) -> pd.DataFrame:
-    return format_paf_data("high_systolic_blood_pressure", location, artifact_path)
-
-
-def load_paf_categorical_sbp(artifact_path: str, key: str, location: str) -> pd.DataFrame:
-    return format_paf_data(
-        "categorical_high_systolic_blood_pressure", location, artifact_path
-    )
-
-
 def load_relative_risk_bmi(key: str, location: str) -> pd.DataFrame:
     standard_rr_data = load_standard_data_enforce_minimum(1, key, location)
 
@@ -875,10 +862,6 @@ def load_relative_risk_bmi(key: str, location: str) -> pd.DataFrame:
     relative_risk_bmi = relative_risk_bmi.sort_index()
 
     return relative_risk_bmi
-
-
-def load_paf_bmi(artifact_path: str, key: str, location: str) -> pd.DataFrame:
-    return format_paf_data("high_body_mass_index_in_adults", location, artifact_path)
 
 
 def get_re_mean_exposure_data_from_me_id(key: str, location: str, me_id: int) -> pd.DataFrame:
@@ -1039,19 +1022,7 @@ def get_age_and_sex_from_paf_output_cols(measure_str):
     return age_start + "," + age_end + "," + sex
 
 
-def format_paf_data(entity: str, location: str, artifact_path: str) -> pd.DataFrame:
-    allowed_entities = [
-        "high_ldl_cholesterol",
-        "high_body_mass_index_in_adults",
-        "high_systolic_blood_pressure",
-        "categorical_high_systolic_blood_pressure",
-    ]
-    if entity not in allowed_entities:
-        raise ValueError(
-            "entity must be high_ldl_cholesterol, high_body_mass_index_in_adults, high_systolic_blood_pressure, or categorical_high_systolic_blood_pressure."
-            f"You provided entity {entity}."
-        )
-
+def load_joint_pafs(artifact_path: str, entity: str, location: str) -> pd.DataFrame:
     population_structure = load_population_structure(
         data_keys.POPULATION.STRUCTURE, location
     ).droplevel("location")
@@ -1061,9 +1032,7 @@ def format_paf_data(entity: str, location: str, artifact_path: str) -> pd.DataFr
     # assume the last path is the correct one
     paf_path = sorted([d for d in pafs_run_dir.iterdir() if d.is_dir()])[-1] / "output.hdf"
     pafs = pd.read_hdf(paf_path)
-    pafs = pafs[
-        [col for col in pafs.columns if "." + entity in col]
-    ].T  # use dot so high sbp doesn't include categorical high sbp
+    pafs = pafs[[col for col in pafs.columns if col.startswith("MEASURE_joint_paf_on_")]].T
     pafs.columns = ARTIFACT_COLUMNS
     pafs = pafs.reset_index()
     pafs["demographics"] = pafs["index"].apply(get_age_and_sex_from_paf_output_cols)
@@ -1124,10 +1093,6 @@ def format_paf_data(entity: str, location: str, artifact_path: str) -> pd.DataFr
     formatted_pafs = formatted_pafs.sort_values(sort_cols).set_index(paf_index_columns)
 
     return formatted_pafs
-
-
-def load_paf_ldl(artifact_path: str, key: str, location: str) -> pd.DataFrame:
-    return format_paf_data("high_ldl_cholesterol", location, artifact_path)
 
 
 def load_sbp_exposure(key: str, location: str) -> pd.DataFrame:

--- a/src/vivarium_nih_us_cvd/model_specifications/paf_calculation.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/paf_calculation.yaml
@@ -12,54 +12,46 @@ components:
             - CategoricalSBPRisk()
             - TruncatedRisk("risk_factor.high_body_mass_index_in_adults")
             - TruncatedRisk("risk_factor.high_ldl_cholesterol")
+            - TruncatedRisk('risk_factor.high_fasting_plasma_glucose')
 
             - RiskCorrelation()
 
             # risk effects
-            - PAFCalculationRiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
-            - PAFCalculationRiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_residual.incidence_rate")
-            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
-            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_residual.incidence_rate")
-
-            - PAFCalculationRiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
-            - PAFCalculationRiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
-            - PAFCalculationRiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_ischemic_stroke.incidence_rate")
-            - PAFCalculationRiskEffect("risk_factor.high_ldl_cholesterol", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
-
-            - PAFCalculationRiskEffect("risk_factor.high_systolic_blood_pressure", "cause.acute_myocardial_infarction.incidence_rate")
-            - PAFCalculationRiskEffect("risk_factor.high_systolic_blood_pressure", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
-            - PAFCalculationRiskEffect("risk_factor.high_systolic_blood_pressure", "cause.acute_ischemic_stroke.incidence_rate")
-            - PAFCalculationRiskEffect("risk_factor.high_systolic_blood_pressure", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
-
-            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.acute_myocardial_infarction.incidence_rate")
-            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
             - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.acute_ischemic_stroke.incidence_rate")
             - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_ischemic_stroke.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_ldl_cholesterol", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_systolic_blood_pressure", "cause.acute_ischemic_stroke.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_systolic_blood_pressure", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.acute_ischemic_stroke.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
+            
+            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.acute_myocardial_infarction.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_systolic_blood_pressure", "cause.acute_myocardial_infarction.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_systolic_blood_pressure", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.acute_myocardial_infarction.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_fasting_plasma_glucose", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
 
-            # PAF observers
-            - PAFObserver("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_residual.incidence_rate")
-            - PAFObserver("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_residual.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.heart_failure_residual.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
+            - PAFCalculationRiskEffect("risk_factor.categorical_high_systolic_blood_pressure", "cause.heart_failure_residual.incidence_rate")
 
-            - PAFObserver("risk_factor.high_ldl_cholesterol", "cause.acute_myocardial_infarction.incidence_rate")
-            - PAFObserver("risk_factor.high_ldl_cholesterol", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
-            - PAFObserver("risk_factor.high_ldl_cholesterol", "cause.acute_ischemic_stroke.incidence_rate")
-            - PAFObserver("risk_factor.high_ldl_cholesterol", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
-
-            - PAFObserver("risk_factor.high_systolic_blood_pressure", "cause.acute_myocardial_infarction.incidence_rate")
-            - PAFObserver("risk_factor.high_systolic_blood_pressure", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
-            - PAFObserver("risk_factor.high_systolic_blood_pressure", "cause.acute_ischemic_stroke.incidence_rate")
-            - PAFObserver("risk_factor.high_systolic_blood_pressure", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
-
-            - PAFObserver("risk_factor.high_body_mass_index_in_adults", "cause.acute_myocardial_infarction.incidence_rate")
-            - PAFObserver("risk_factor.high_body_mass_index_in_adults", "cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
-            - PAFObserver("risk_factor.high_body_mass_index_in_adults", "cause.acute_ischemic_stroke.incidence_rate")
-            - PAFObserver("risk_factor.high_body_mass_index_in_adults", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
+            # joint PAF observers
+            - JointPAFObserver("cause.acute_ischemic_stroke.incidence_rate")
+            - JointPAFObserver("cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")
+            - JointPAFObserver("cause.acute_myocardial_infarction.incidence_rate")
+            - JointPAFObserver("cause.post_myocardial_infarction_to_acute_myocardial_infarction.transition_rate")
+            - JointPAFObserver("cause.heart_failure_from_ischemic_heart_disease.incidence_rate")
+            - JointPAFObserver("cause.heart_failure_residual.incidence_rate")
 
 configuration:
     input_data:
         input_draw_number: 0
-        location: 'Alabama'
-        artifact_path: '/home/hussain-jafari/artifacts/alabama.hdf'
+        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
     interpolation:
         order: 0
         extrapolate: True
@@ -88,16 +80,21 @@ configuration:
         exit_age: 100
     stratification:
         default: ['sex', 'age_group']
-        high_systolic_blood_pressure_paf:
-            include: ['sex', 'age_group']
-            exclude: [ ]
-        categorical_high_systolic_blood_pressure_paf:
-            include: ['sex', 'age_group']
-            exclude: [ ]
-        high_body_mass_index_in_adults_paf:
-            include: ['sex', 'age_group']
-            exclude: [ ]
-        high_ldl_cholesterol_paf:
-            include: ['sex', 'age_group']
-            exclude: [ ]
-
+        # acute_ischemic_stroke_paf:
+        #     include: [ ]
+        #     exclude: [ ]
+        # chronic_ischemic_stroke_to_acute_ischemic_stroke_paf:
+        #     include: [ ]
+        #     exclude: [ ]
+        # acute_myocardial_infarction_paf:
+        #     include: [ ]
+        #     exclude: [ ]
+        # post_myocardial_infarction_to_acute_myocardial_infarction_paf:
+        #     include: [ ]
+        #     exclude: [ ]
+        # heart_failure_from_ischemic_heart_disease_paf:
+        #     include: [ ]
+        #     exclude: [ ]
+        # heart_failure_residual_paf:
+        #     include: [ ]
+        #     exclude: [ ]

--- a/src/vivarium_nih_us_cvd/model_specifications/paf_calculation.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/paf_calculation.yaml
@@ -80,21 +80,3 @@ configuration:
         exit_age: 100
     stratification:
         default: ['sex', 'age_group']
-        # acute_ischemic_stroke_paf:
-        #     include: [ ]
-        #     exclude: [ ]
-        # chronic_ischemic_stroke_to_acute_ischemic_stroke_paf:
-        #     include: [ ]
-        #     exclude: [ ]
-        # acute_myocardial_infarction_paf:
-        #     include: [ ]
-        #     exclude: [ ]
-        # post_myocardial_infarction_to_acute_myocardial_infarction_paf:
-        #     include: [ ]
-        #     exclude: [ ]
-        # heart_failure_from_ischemic_heart_disease_paf:
-        #     include: [ ]
-        #     exclude: [ ]
-        # heart_failure_residual_paf:
-        #     include: [ ]
-        #     exclude: [ ]


### PR DESCRIPTION
## Joint PAFs to artifact
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> implementation, artifact
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4579
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/risk_correlation/sbp_ldlc_fpg_bmi/index.html#joint-paf-calculations

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

With correlated risk factors we can no longer assume independence and so need
to modify the PAF calculation. This is done by calculating a joint PAF per
group-target instead of individual risk-target PAFs.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Confirmed the new PAFs are in the artifact for all six targets
![image](https://github.com/ihmeuw/vivarium_nih_us_cvd/assets/23350991/b74dab59-6928-443a-b35b-829936ccd192)

