### PR TITLE
implement joint PAF modifier

### DIFF
--- a/src/vivarium_nih_us_cvd/components/effects.py
+++ b/src/vivarium_nih_us_cvd/components/effects.py
@@ -164,8 +164,14 @@ class MediatedRiskEffect(RiskEffect):
         self.mediated_target_modifier = self.get_mediated_target_modifier(builder)
         self.register_mediated_target_modifier(builder)
 
+    #################
+    # Setup methods #
+    #################
+
     def register_target_modifier(self, builder: Builder) -> None:
-        """We do not want to register the super's target modifier, so we override it here"""
+        pass
+
+    def register_paf_modifier(self, builder: Builder) -> None:
         pass
 
     def get_mediated_target_modifier(

--- a/src/vivarium_nih_us_cvd/components/risk_correlation.py
+++ b/src/vivarium_nih_us_cvd/components/risk_correlation.py
@@ -68,8 +68,8 @@ class RiskCorrelation(Component):
             "risk_factor.joint_mediated_risks.population_attributable_fraction"
         )
         pafs = {}
-        for name, group in paf_data.groupby(["affected_entity", "affected_measure"]):
-            target = EntityKey(f"cause.{name[0]}.{name[1]}")
+        for (name, measure), group in paf_data.groupby(["affected_entity", "affected_measure"]):
+            target = EntityKey(f"cause.{name}.{measure}")
             data = group.drop(columns=["affected_entity", "affected_measure"])
             pafs[target] = builder.lookup.build_table(
                 data, key_columns=["sex"], parameter_columns=["age", "year"]

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -1019,9 +1019,6 @@ def load_joint_pafs(artifact_path: str, entity: str, location: str) -> pd.DataFr
     affected_entity_col = pd.Series(
         [output_col.split(".")[-2] for output_col in pafs["index"]]
     )
-    affected_entity_col = affected_entity_col.replace(
-        "heart_failure_residual", "heart_failure"
-    )
     affected_measure_col = pd.Series(
         [output_col.split(".")[-1].split("_AGE_GROUP")[0] for output_col in pafs["index"]]
     )


### PR DESCRIPTION
## joint PAF implementation
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4583
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/risk_correlation/sbp_ldlc_fpg_bmi/index.html#joint-paf-calculations

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

joint PAFs are loaded directly into the artifact now so we no longer need to
calculate them the normal way. To implement, we overwrite the
RiskEffect `register_paf_modifier` to pass and do the custom registration
in the risk_correlation module (perhaps not a perfect spot for it but we needed
somewhere that wasn't registering on a risk-target basis and all these changes
are indeed required due to correlation so that seems better than creating a
new component just to handle this)

The default `list_combiner` and `union_post_processor` used when registering
the PAF pipelines (vph.disease.transition::RateTransition) should still work correctly;
it's just that now we only have a single-item list per target.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

ran a couple of time steps.

