### PR TITLE
re-work therapeutic inertia

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ if __name__ == "__main__":
     data_requirements = ["vivarium_inputs[data]==4.1.0"]
     cluster_requirements = ["vivarium_cluster_tools>=1.3.13"]
     test_requirements = ["pytest"]
-    dev_requirements = ["black", "isort"]
 
     setup(
         name=about["__title__"],
@@ -51,7 +50,7 @@ if __name__ == "__main__":
             "test": test_requirements,
             "cluster": cluster_requirements,
             "data": data_requirements + cluster_requirements,
-            "dev": test_requirements + cluster_requirements + dev_requirements,
+            "dev": test_requirements + cluster_requirements,
         },
         zip_safe=False,
         use_scm_version={

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ if __name__ == "__main__":
     data_requirements = ["vivarium_inputs[data]==4.1.0"]
     cluster_requirements = ["vivarium_cluster_tools>=1.3.13"]
     test_requirements = ["pytest"]
+    dev_requirements = ["black", "isort"]
 
     setup(
         name=about["__title__"],
@@ -50,7 +51,7 @@ if __name__ == "__main__":
             "test": test_requirements,
             "cluster": cluster_requirements,
             "data": data_requirements + cluster_requirements,
-            "dev": test_requirements + cluster_requirements,
+            "dev": test_requirements + cluster_requirements + dev_requirements,
         },
         zip_safe=False,
         use_scm_version={

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -851,7 +851,7 @@ class Treatment(Component):
         above_medium_ldlc = measured_ldlc[
             measured_ldlc >= data_values.LDLC_THRESHOLD.MEDIUM
         ].index
-        old_pop = pop_visitors[pop_visitors["age"] >= 75].index
+        old_pop = pop_visitors[pop_visitors["age"] >= 70].index
         newly_prescribed_young = (
             overcome_prescription_inertia.difference(currently_medicated)
             .difference(low_ascvd)

--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -851,7 +851,7 @@ class Treatment(Component):
         above_medium_ldlc = measured_ldlc[
             measured_ldlc >= data_values.LDLC_THRESHOLD.MEDIUM
         ].index
-        old_pop = pop_visitors[pop_visitors["age"] >= 70].index
+        old_pop = pop_visitors[pop_visitors["age"] >= data_values.LDLC_OLD_AGE_THRESHOLD].index
         newly_prescribed_young = (
             overcome_prescription_inertia.difference(currently_medicated)
             .difference(low_ascvd)

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -127,6 +127,7 @@ VISIT_TYPE = __VisitType()
 # Medication Parameters #
 #########################
 
+LDLC_OLD_AGE_THRESHOLD = 70.0
 
 # Therapeutic inertias (probability that a patient will not have their medication changed)
 class __SBPTherapeuticInertia(NamedTuple):

--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -25,8 +25,12 @@ class __Columns(NamedTuple):
     POLYPILL: str = "polypill"
     LIFESTYLE: str = "lifestyle"
     LAST_FPG_TEST_DATE: str = "last_fpg_test_date"
-    SBP_THERAPEUTIC_INERTIA_PROPENSITY: str = "sbp_therapeutic_inertia_propensity"
-    LDLC_THERAPEUTIC_INERTIA_PROPENSITY: str = "ldlc_therapeutic_inertia_propensity"
+    SBP_THERAPEUTIC_INERTIA_CONSTANT_COMPONENT: str = (
+        "sbp_therapeutic_inertia_constant_component"
+    )
+    LDLC_THERAPEUTIC_INERTIA_CONSTANT_COMPONENT: str = (
+        "ldlc_therapeutic_inertia_constant_component"
+    )
 
     @property
     def name(self):
@@ -123,9 +127,21 @@ VISIT_TYPE = __VisitType()
 # Medication Parameters #
 #########################
 
+
 # Therapeutic inertias (probability that a patient will not have their medication changed)
-SBP_THERAPEUTIC_INERTIA = 0.4176
-LDLC_THERAPEUTIC_INERTIA = 0.194
+class __SBPTherapeuticInertia(NamedTuple):
+    FIRST_MEDICATION: float = 0.8
+    CHANGE_MEDICATION: float = 0.87
+
+    @property
+    def name(self):
+        return "sbp_therapeutic_inertia"
+
+
+SBP_THERAPEUTIC_INERTIA = __SBPTherapeuticInertia()
+
+
+LDLC_THERAPEUTIC_INERTIA = 0.84
 
 
 class __SBPThreshold(NamedTuple):
@@ -343,6 +359,10 @@ BASELINE_MEDICATION_LEVEL_PROBABILITY = {
 # Define first-prescribed medication ramp levels for simulants who overcome therapeutic inertia
 FIRST_PRESCRIPTION_LEVEL_PROBABILITY = {
     "sbp": {
+        "medium": {
+            SBP_MEDICATION_LEVEL.ONE_DRUG_HALF_DOSE.DESCRIPTION: 0.795,
+            SBP_MEDICATION_LEVEL.TWO_DRUGS_HALF_DOSE.DESCRIPTION: 0.205,
+        },
         "high": {
             SBP_MEDICATION_LEVEL.ONE_DRUG_HALF_DOSE.DESCRIPTION: 0.55,
             SBP_MEDICATION_LEVEL.TWO_DRUGS_HALF_DOSE.DESCRIPTION: 0.45,
@@ -366,8 +386,9 @@ FIRST_PRESCRIPTION_LEVEL_PROBABILITY = {
             LDLC_MEDICATION_LEVEL.HIGH.DESCRIPTION: 0.24,
         },
         # [Treatment ramp ID F] Simulants who overcome therapeutic inertia, have
-        # elevated LDLC, are not currently medicated, have elevated ASCVD, have
-        # no history of MI or IS, but who do NOT have high LDLC or ASCVD
+        # elevated LDLC, are not currently medicated, and are either (1) old or
+        # (2) have elevated ASCVD, have no history of MI or IS, but who do NOT
+        # have high LDLC or ASCVD
         "ramp_id_f": {
             LDLC_MEDICATION_LEVEL.LOW.DESCRIPTION: 0.14,
             LDLC_MEDICATION_LEVEL.MED.DESCRIPTION: 0.71,

--- a/src/vivarium_nih_us_cvd/utilities.py
+++ b/src/vivarium_nih_us_cvd/utilities.py
@@ -59,34 +59,6 @@ def delete_if_exists(*paths: Union[Path, List[Path]], confirm=False):
             p.unlink()
 
 
-def read_data_by_draw(artifact_path: str, key: str, draw: int) -> pd.DataFrame:
-    """Reads data from the artifact on a per-draw basis. This
-    is necessary for Low Birthweight Short Gestation (LBWSG) data.
-
-    Parameters
-    ----------
-    artifact_path
-        The artifact to read from.
-    key
-        The entity key associated with the data to read.
-    draw
-        The data to retrieve.
-
-    """
-    key = key.replace(".", "/")
-    with pd.HDFStore(artifact_path, mode="r") as store:
-        index = store.get(f"{key}/index")
-        draw = store.get(f"{key}/draw_{draw}")
-    draw = draw.rename("value")
-    data = pd.concat([index, draw], axis=1)
-    data = data.drop(columns="location")
-    data = pivot_categorical(data)
-    data[
-        project_globals.LBWSG_MISSING_CATEGORY.CAT
-    ] = project_globals.LBWSG_MISSING_CATEGORY.EXPOSURE
-    return data
-
-
 def get_norm(
     mean: float,
     sd: float = None,


### PR DESCRIPTION
## Update approach to therapeutic inertia
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4605
- *Research reference*: <!--Link to research documentation for code --> PR with changes https://github.com/ihmeuw/vivarium_research/pull/1353/files

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

There are four main changes here:
1. Changes to the inertia thresholds
2. Newly-medicated simulants with medium-level sbp can get two types of
  medication now.
3. The calculation of inertia propensity is totally different; it now consists of
  a constant simulant-level component plus a dynamic component.
4. When simulants are considered for treatment changes now occurs 
  at every hospital visit.

NOTE: I think I found a bug w/ the previous implementation. Previously, for
the sbp treatment ramp, newly treated simulants in block B only got put on
medication if they were adherent but I think they were just all supposed to be
put on the treatment (like block C). I've asked for confirmation from Syl.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Ran a few time steps.
