### PR TITLE
register paf modifier in new component

### DIFF
--- a/src/vivarium_nih_us_cvd/components/__init__.py
+++ b/src/vivarium_nih_us_cvd/components/__init__.py
@@ -17,6 +17,6 @@ from .observers import (
     SimpleResultsStratifier,
 )
 from .population import EvenlyDistributedPopulation
-from .risk_correlation import RiskCorrelation
+from .risk_correlation import JointPAF, RiskCorrelation
 from .risks import AdjustedRisk, CategoricalSBPRisk, TruncatedRisk
 from .treatment import Treatment

--- a/src/vivarium_nih_us_cvd/model_specifications/branches/paf_scenarios.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/branches/paf_scenarios.yaml
@@ -1,5 +1,6 @@
 input_draw_count: 1000
 random_seed_count: 1
+random_seeds: [9876]
 
 branches:
   - intervention:

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -28,6 +28,7 @@ components:
             - ContinuousRiskObserver("risk_factor.high_fasting_plasma_glucose")
 
             - RiskCorrelation()
+            - JointPAF()
 
             - MediatedRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.acute_ischemic_stroke.incidence_rate")
             - MediatedRiskEffect("risk_factor.high_body_mass_index_in_adults", "cause.chronic_ischemic_stroke_to_acute_ischemic_stroke.transition_rate")


### PR DESCRIPTION
## New PAF modifier component
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> bugfix
- *JIRA issue*: na
- *Research reference*: <!--Link to research documentation for code --> na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
When I tested the mediation stuff last week I must have accidentally been
using an old artifact that included the 
`risk_factor.joint_mediated_risks.popoulation_attributable_fraction` key
during the PAF run (where it shouldn't yet exist). The problem is that
during the PAF run we can't load the PAFs yet (obviously) so this was missed.

This PR makes a new component used just for registering PAF modifiers;
it is included in real sim but NOT the PAF sim.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Ran a few time steps on a shiny new artifact.
