### PR TITLE
Feature/sbachmei/mic 4693 initialize medication discontinuation

### DIFF
--- a/src/vivarium_nih_us_cvd/constants/data_values.py
+++ b/src/vivarium_nih_us_cvd/constants/data_values.py
@@ -14,8 +14,12 @@ class __Columns(NamedTuple):
     SCHEDULED_VISIT_DATE: str = "scheduled_date"
     SBP_MEDICATION: str = "sbp_medication"
     SBP_MEDICATION_ADHERENCE: str = "sbp_medication_adherence"
+    SBP_MEDICATION_START_DATE: str = "sbp_medication_start_date"
+    DISCONTINUED_SBP_MEDICATION: str = "discontinued_sbp_medication"
     LDLC_MEDICATION: str = "ldlc_medication"
     LDLC_MEDICATION_ADHERENCE: str = "ldlc_medication_adherence"
+    LDLC_MEDICATION_START_DATE: str = "ldlc_medication_start_date"
+    DISCONTINUED_LDLC_MEDICATION: str = "discontinued_ldlc_medication"
     LIFESTYLE_ADHERENCE: str = "lifestyle_adherence"
     BASELINE_SBP_MEDICATION: str = "baseline_sbp_medication"
     BASELINE_LDLC_MEDICATION: str = "baseline_ldlc_medication"
@@ -404,6 +408,9 @@ FIRST_PRESCRIPTION_LEVEL_PROBABILITY = {
         },
     },
 }
+
+INITIALIZATION_MEDICATON_START_DATE_YEARS_IN_PAST = 3.0
+MEDICATION_DISCONTINUATION_PROBABILITY = 0.314
 
 
 class __MedicationAdherenceType(NamedTuple):

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -90,7 +90,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_nih_us_cvd/alabama.hdf'
+        artifact_path: '/mnt/team/simulation_science/pub/models/vivarium_nih_us_cvd/artifacts/51-locations/v3-20231019/alabama.hdf'
     interpolation:
         order: 0
         extrapolate: True


### PR DESCRIPTION
## Initialize medication discontinuatioin

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4693
- *Research reference*: <!--Link to research documentation for code --> https://github.com/ihmeuw/vivarium_research/pull/1386/files

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
NOTE: you can ignore the first commit - it just shuffles some of the
Treatment methods around

This is the first of two PRs to implement medication discontinuation.
This PR only initializes simulant discontinuation but then does not
actually do anything with them.

During initialization, four new columns are created:
- sbp_medication_start_date
- ldlc_medication_start_date
- discontinued_sbp_medication
- discontinued_ldlc_medication

Per the docs, we need to:
1. Add medication start dates for simulants initialized as on treatment between
  0 and 3 years in the past.
2. Set 31.4% of simulants initialized as not on treatment as actually having
  been discontinued prior to the sim start.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Ran a few time steps. Nothing broke and the initialized columns exist and
seem correct.


