### PR TITLE
remove unnecessary observers; stop saving out hdf

### DIFF
--- a/src/vivarium_nih_us_cvd/components/treatment.py
+++ b/src/vivarium_nih_us_cvd/components/treatment.py
@@ -763,7 +763,7 @@ class Treatment(Component):
 
         # Initialize medication discontinuation
         not_medicated_idx = pop.index.difference(medicated_idx)
-        # NOTE: The raw discontinuation "relative risk" values were scaled by RT such 
+        # NOTE: The raw discontinuation "relative risk" values were scaled by RT such
         # that the scaled probabilities that get calculated in the Treatment component
         # are <= ~0.95. Ensure future data updates guarantee this as well or
         # the issue is otherwise handled.
@@ -773,7 +773,7 @@ class Treatment(Component):
                 data_values.COLUMNS.LDLC_MEDICATION: "ldl_rr",
             }[medication_col]
         ]
-        probs = (data_values.MEDICATION_DISCONTINUATION_PROBABILITY / scaling_factor)
+        probs = data_values.MEDICATION_DISCONTINUATION_PROBABILITY / scaling_factor
         discontinued_idx = self.randomness.filter_for_probability(
             population=not_medicated_idx,
             probability=probs,
@@ -800,7 +800,7 @@ class Treatment(Component):
         maybe_discontinue_idx = treated_idx.intersection(started_recently_idx)
 
         # The probability of discontinuing is per year so we can convert that to a rate and scale
-        # NOTE: The raw discontinuation "relative risk" values were scaled by RT such 
+        # NOTE: The raw discontinuation "relative risk" values were scaled by RT such
         # that the scaled probabilities that get calculated in the Treatment component
         # are <= ~0.95. Ensure future data updates guarantee this as well or
         # the issue is otherwise handled.
@@ -810,7 +810,7 @@ class Treatment(Component):
                 data_values.COLUMNS.LDLC_MEDICATION: "ldl_rr",
             }[medication_col]
         ]
-        probs = (data_values.MEDICATION_DISCONTINUATION_PROBABILITY / scaling_factor)
+        probs = data_values.MEDICATION_DISCONTINUATION_PROBABILITY / scaling_factor
         scaled_rates = probability_to_rate(probs) * self.step_size().days / 365.25
 
         discontinue_idx = self.randomness.filter_for_rate(

--- a/src/vivarium_nih_us_cvd/constants/results.py
+++ b/src/vivarium_nih_us_cvd/constants/results.py
@@ -55,19 +55,19 @@ COLUMN_TEMPLATES = {
     "ylds": YLDS_COLUMN_TEMPLATE,
     "state_person_time": STATE_PERSON_TIME_COLUMN_TEMPLATE,
     "transition_count": TRANSITION_COUNT_COLUMN_TEMPLATE,
-    "risk_exposure_time": RISK_EXPOSURE_TIME_TEMPLATE,
+    # "risk_exposure_time": RISK_EXPOSURE_TIME_TEMPLATE,
     "binned_ldl_exposure_time": BINNED_LDL_EXPOSURE_TIME_TEMPLATE,
     "binned_sbp_exposure_time": BINNED_SBP_EXPOSURE_TIME_TEMPLATE,
-    "healthcare_visits": VISIT_COUNT_TEMPLATE,
-    "sbp_medication_person_time": SBP_MEDICATION_PERSON_TIME_TEMPLATE,
-    "ldlc_medication_person_time": LDLC_MEDICATION_PERSON_TIME_TEMPLATE,
-    "intervention_person_time": INTERVENTION_PERSON_TIME_TEMPLATE,
+    # "healthcare_visits": VISIT_COUNT_TEMPLATE,
+    # "sbp_medication_person_time": SBP_MEDICATION_PERSON_TIME_TEMPLATE,
+    # "ldlc_medication_person_time": LDLC_MEDICATION_PERSON_TIME_TEMPLATE,
+    # "intervention_person_time": INTERVENTION_PERSON_TIME_TEMPLATE,
 }
 
 NON_COUNT_TEMPLATES = []
 
 SEXES = ("Male", "Female")
-YEARS = tuple(range(2021, 2041))
+YEARS = tuple(range(2023, 2025))
 AGE_GROUPS = (
     "25_to_29",
     "30_to_34",
@@ -135,15 +135,15 @@ TEMPLATE_FIELD_MAP = {
         for model in STATE_MACHINE_MAP
         for transition in STATE_MACHINE_MAP[model]["transitions"]
     ],
-    "RISK": RISKS,
+    # "RISK": RISKS,
     "BINNED_LDL_LIMITS": BINNED_LDL_LIMITS,
     "BINNED_SBP_LIMITS": BINNED_SBP_LIMITS,
-    "VISIT_TYPE": data_values.VISIT_TYPE,
-    "MEDICATION_ADHERENCE": MEDICATION_ADHERENCES,
-    "SBP_MEDICATION": SBP_MEDICATIONS,
-    "LDLC_MEDICATION": LDLC_MEDICATIONS,
-    "INTERVENTION_TYPE": INTERVENTION_TYPES,
-    "INTERVENTION": INTERVENTIONS,
+    # "VISIT_TYPE": data_values.VISIT_TYPE,
+    # "MEDICATION_ADHERENCE": MEDICATION_ADHERENCES,
+    # "SBP_MEDICATION": SBP_MEDICATIONS,
+    # "LDLC_MEDICATION": LDLC_MEDICATIONS,
+    # "INTERVENTION_TYPE": INTERVENTION_TYPES,
+    # "INTERVENTION": INTERVENTIONS,
 }
 
 

--- a/src/vivarium_nih_us_cvd/constants/results.py
+++ b/src/vivarium_nih_us_cvd/constants/results.py
@@ -67,7 +67,7 @@ COLUMN_TEMPLATES = {
 NON_COUNT_TEMPLATES = []
 
 SEXES = ("Male", "Female")
-YEARS = tuple(range(2023, 2025))
+YEARS = tuple(range(2021, 2041))
 AGE_GROUPS = (
     "25_to_29",
     "30_to_34",

--- a/src/vivarium_nih_us_cvd/data/loader.py
+++ b/src/vivarium_nih_us_cvd/data/loader.py
@@ -1259,7 +1259,7 @@ def load_hf_deltas(_: str, location) -> pd.Series:
 
 
 def load_medication_coverage_scaling_factor(_: str, location: str):
-    # NOTE: The raw discontinuation "relative risk" values were scaled by RT such 
+    # NOTE: The raw discontinuation "relative risk" values were scaled by RT such
     # that the scaled probabilities that get calculated in the Treatment component
     # are <= ~0.95. Ensure future data updates guarantee this as well or
     # the issue is otherwise handled.

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -101,16 +101,16 @@ configuration:
         random_seed: 0
     time:
         start:
-            year: 2023 # Includes two years for burn-in
+            year: 2021 # Includes two years for burn-in
             month: 1
             day: 1
         end:
-            year: 2024
+            year: 2040
             month: 12
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 10_000
+        population_size: 50_000
         age_start: 5
         age_end: 125
         exit_age: 125

--- a/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
+++ b/src/vivarium_nih_us_cvd/model_specifications/nih_us_cvd.yaml
@@ -11,21 +11,22 @@ components:
     vivarium_nih_us_cvd:
         components:
         
-            - ResultsStratifier()
+            # - ResultsStratifier()
+            - SimpleResultsStratifier()
 
             - AdjustedRisk("risk_factor.high_ldl_cholesterol")
-            - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
+            # - ContinuousRiskObserver("risk_factor.high_ldl_cholesterol")
             - BinnedRiskObserver("risk_factor.high_ldl_cholesterol")
 
             - AdjustedRisk("risk_factor.high_systolic_blood_pressure")
-            - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
+            # - ContinuousRiskObserver("risk_factor.high_systolic_blood_pressure")
             - BinnedRiskObserver("risk_factor.high_systolic_blood_pressure")
 
             - TruncatedRisk("risk_factor.high_body_mass_index_in_adults")
-            - ContinuousRiskObserver("risk_factor.high_body_mass_index_in_adults")
+            # - ContinuousRiskObserver("risk_factor.high_body_mass_index_in_adults")
 
             - TruncatedRisk('risk_factor.high_fasting_plasma_glucose')
-            - ContinuousRiskObserver("risk_factor.high_fasting_plasma_glucose")
+            # - ContinuousRiskObserver("risk_factor.high_fasting_plasma_glucose")
 
             - RiskCorrelation()
             - JointPAF()
@@ -56,18 +57,18 @@ components:
             - CategoricalSBPRisk()
 
             - HealthcareUtilization()  # NOTE: this uses Treatment() as a sub-component
-            - HealthcareVisitObserver()
+            # - HealthcareVisitObserver()
 
-            - CategoricalColumnObserver("sbp_medication")
-            - CategoricalColumnObserver("ldlc_medication")
+            # - CategoricalColumnObserver("sbp_medication")
+            # - CategoricalColumnObserver("ldlc_medication")
 
             - InterventionAdherenceEffect()
             - LinearScaleUp("risk_factor.outreach")
             - LinearScaleUp("risk_factor.polypill")
             - LinearScaleUp("risk_factor.lifestyle")
-            - CategoricalColumnObserver("outreach")
-            - CategoricalColumnObserver("polypill")
-            - LifestyleObserver()
+            # - CategoricalColumnObserver("outreach")
+            # - CategoricalColumnObserver("polypill")
+            # - LifestyleObserver()
 
     vivarium_public_health:
         population:
@@ -100,16 +101,16 @@ configuration:
         random_seed: 0
     time:
         start:
-            year: 2021 # Includes two years for burn-in
+            year: 2023 # Includes two years for burn-in
             month: 1
             day: 1
         end:
-            year: 2040
+            year: 2024
             month: 12
             day: 31
         step_size: 28 # Days
     population:
-        population_size: 50_000
+        population_size: 10_000
         age_start: 5
         age_end: 125
         exit_age: 125
@@ -118,12 +119,12 @@ configuration:
             - 'age_group'
             - 'sex'
             - 'current_year'
-        sbp_medication:
-            include:
-                - 'sbp_medication_adherence'
-        ldlc_medication:
-            include:
-                - 'ldlc_medication_adherence'
+        # sbp_medication:
+        #     include:
+        #         - 'sbp_medication_adherence'
+        # ldlc_medication:
+        #     include:
+        #         - 'ldlc_medication_adherence'
     
     outreach:
         exposure: 0

--- a/src/vivarium_nih_us_cvd/results_processing/process_results.py
+++ b/src/vivarium_nih_us_cvd/results_processing/process_results.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Union
+from typing import Dict, List, NamedTuple, Optional, Union
 
 import pandas as pd
 import yaml
@@ -34,19 +34,19 @@ def make_measure_data(data):
         deaths=get_measure_data(data, "deaths"),
         state_person_time=get_measure_data(data, "state_person_time"),
         transition_count=get_transition_count_measure_data(data, "transition_count"),
-        risk_exposure_time=get_measure_data(data, "risk_exposure_time"),
+        # risk_exposure_time=get_measure_data(data, "risk_exposure_time"),
         binned_ldl_exposure_time=get_measure_data(data, "binned_ldl_exposure_time"),
         binned_sbp_exposure_time=get_measure_data(data, "binned_sbp_exposure_time"),
-        healthcare_visits=get_measure_data(data, "healthcare_visits"),
-        sbp_medication_person_time=get_medication_person_time_data(
-            data, "sbp_medication_person_time"
-        ),
-        ldlc_medication_person_time=get_medication_person_time_data(
-            data, "ldlc_medication_person_time"
-        ),
-        intervention_person_time=get_intervention_person_time_data(
-            data, "intervention_person_time"
-        ),
+        # healthcare_visits=get_measure_data(data, "healthcare_visits"),
+        # sbp_medication_person_time=get_medication_person_time_data(
+        #     data, "sbp_medication_person_time"
+        # ),
+        # ldlc_medication_person_time=get_medication_person_time_data(
+        #     data, "ldlc_medication_person_time"
+        # ),
+        # intervention_person_time=get_intervention_person_time_data(
+        #     data, "intervention_person_time"
+        # ),
     )
     return measure_data
 
@@ -57,17 +57,17 @@ class MeasureData(NamedTuple):
     deaths: pd.DataFrame
     state_person_time: pd.DataFrame
     transition_count: pd.DataFrame
-    risk_exposure_time: pd.DataFrame
+    # risk_exposure_time: pd.DataFrame
     binned_ldl_exposure_time: pd.DataFrame
     binned_sbp_exposure_time: pd.DataFrame
-    healthcare_visits: pd.DataFrame
-    sbp_medication_person_time: pd.DataFrame
-    ldlc_medication_person_time: pd.DataFrame
-    intervention_person_time: pd.DataFrame
+    # healthcare_visits: pd.DataFrame
+    # sbp_medication_person_time: pd.DataFrame
+    # ldlc_medication_person_time: pd.DataFrame
+    # intervention_person_time: pd.DataFrame
 
     def dump(self, output_dir: Path):
         for key, df in self._asdict().items():
-            df.to_hdf(output_dir / f"{key}.hdf", key=key)
+            # df.to_hdf(output_dir / f"{key}.hdf", key=key)
             df.to_csv(output_dir / f"{key}.csv")
 
 
@@ -94,15 +94,16 @@ def read_data(path: Path, single_run: bool) -> (pd.DataFrame, List[str]):
             results.RANDOM_SEED_COLUMN: [0],
             results.OUTPUT_SCENARIO_COLUMN: [scenarios.INTERVENTION_SCENARIOS.BASELINE.name],
         }
+        data[LOCATION_COLUMN] = path.parent.parent.name
     else:
         data[results.INPUT_DRAW_COLUMN] = data[results.INPUT_DRAW_COLUMN].astype(int)
         data[results.RANDOM_SEED_COLUMN] = data[results.RANDOM_SEED_COLUMN].astype(int)
         with (path.parent / "keyspace.yaml").open() as f:
             keyspace = yaml.full_load(f)
-    # Convert the artifacts to locations
-    data[LOCATION_COLUMN] = data[ARTIFACT_COLUMN].apply(
-        lambda x: str(Path(x).name).split(".")[0]
-    )
+        # Convert the artifacts to locations
+        data[LOCATION_COLUMN] = data[ARTIFACT_COLUMN].apply(
+            lambda x: str(Path(x).name).split(".")[0]
+        )
     return data, keyspace
 
 


### PR DESCRIPTION
## remove unnecessary observers; stop saving out hdf
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> misc
- *JIRA issue*: na
- *Research reference*: <!--Link to research documentation for code --> remove unnecessary observers; stop saving out hdf

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> I forgot to remove the  unnecessary observers for the timing runs; doing that now.

I also found that there's a bug and the transition_count.hdf is somehow corrupted
and unable to be opened (and I suspect this has been a bug for a very long time;
I confirmed it exists in the oldest data we have which is back in August). I confirmed
with Syl that she doesn't ever use the hdfs so I just stopped saving them out.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

